### PR TITLE
fix: Mention how to use memcache_port

### DIFF
--- a/docs/managing-dragonfly/running-memcached.md
+++ b/docs/managing-dragonfly/running-memcached.md
@@ -1,0 +1,13 @@
+---
+sidebar_position: 5
+---
+
+# Running in Memcached mode
+
+Use the `memcache_port` flag to select a port for exposing the Memcached compatible interface. By default it's disabled.
+
+For example, to run on Memcached's default port, use
+
+```
+./dragonfly  --memcache_port 11211
+```


### PR DESCRIPTION
1. Its that brief, should I really add a new page for it?
2. The cache is officially called memcache**d**, maybe we should rename the flag until its too late?