### PR TITLE
Update docker-compose.md: change `docker-compose` to `docker compose`

### DIFF
--- a/docs/getting-started/docker-compose.md
+++ b/docs/getting-started/docker-compose.md
@@ -16,7 +16,7 @@ If you do not have `docker` and `docker-compose` installed on your machine, befo
 wget https://raw.githubusercontent.com/dragonflydb/dragonfly/main/contrib/docker/docker-compose.yml
 
 # Launch the Dragonfly Instance
-docker-compose up -d
+docker compose up -d
 
 # Confirm image is up
 docker ps | grep dragonfly


### PR DESCRIPTION
`docker-compose` is the old syntax that doesn't even work on fresh installs without special tweaks while `docker compose` is the recommended syntax