### PR TITLE
feat: update docs to include the first batch of geo commands

### DIFF
--- a/docs/command-reference/geospatial-indices/_category_.yml
+++ b/docs/command-reference/geospatial-indices/_category_.yml
@@ -1,0 +1,4 @@
+position: 11
+label: Geospatial indices
+link:
+  type: generated-index

--- a/docs/command-reference/geospatial-indices/geoadd.md
+++ b/docs/command-reference/geospatial-indices/geoadd.md
@@ -8,7 +8,7 @@ description: Add one or more members to a geospatial index
 
     GEOADD key [NX | XX] [CH] longitude latitude member [longitude latitude member ...]
 
-**Time complexity:** O(log(N)) for each item added, where N is the number of elements in the geospatial index represented by a sorted set.
+**Time complexity:** O(log(N)) for each item added, where N is the number of elements in the geospatial index represented by the sorted set.
 
 Adds the specified geospatial items (longitude, latitude, name) to the specified key.
 Data is stored into the key as a sorted set, in a way that makes it possible to query the items with the `GEOSEARCH` command.

--- a/docs/command-reference/geospatial-indices/geoadd.md
+++ b/docs/command-reference/geospatial-indices/geoadd.md
@@ -22,7 +22,7 @@ There are limits to the coordinates that can be indexed: areas very near to the 
 
 - `XX` -- Only update elements that already exist. Never add elements.
 - `NX` -- Don't update already existing elements. Always add new elements.
-- `CH` -- Modify the return value from the number of new elements added, to the total number of elements changed (CH is an abbreviation of changed).
+- `CH` -- Modify the return value from the number of new elements added, to the total number of elements changed (`CH` is an abbreviation of changed).
 Changed elements are new elements added and elements already existing for which the coordinates were updated.
 So elements specified in the command line having the same score as they had in the past are not counted.
 Normally, the return value of `GEOADD` only counts the number of new elements added.

--- a/docs/command-reference/geospatial-indices/geoadd.md
+++ b/docs/command-reference/geospatial-indices/geoadd.md
@@ -1,5 +1,5 @@
 ---
-description: Add one or more geospatial items (longitude, latitude, name) to a geospatial index
+description: Add one or more members to a geospatial index
 ---
 
 # GEOADD
@@ -8,7 +8,7 @@ description: Add one or more geospatial items (longitude, latitude, name) to a g
 
     GEOADD key [NX | XX] [CH] longitude latitude member [longitude latitude member ...]
 
-**Time complexity:** O(log(N)) for each item added, where N is the number of elements in the sorted set.
+**Time complexity:** O(log(N)) for each item added, where N is the number of elements in the geospatial index represented by a sorted set.
 
 Adds the specified geospatial items (longitude, latitude, name) to the specified key.
 Data is stored into the key as a sorted set, in a way that makes it possible to query the items with the `GEOSEARCH` command.

--- a/docs/command-reference/geospatial-indices/geoadd.md
+++ b/docs/command-reference/geospatial-indices/geoadd.md
@@ -14,27 +14,27 @@ Adds the specified geospatial items (longitude, latitude, name) to the specified
 Data is stored into the key as a sorted set, in a way that makes it possible to query the items with the `GEOSEARCH` command.
 
 The command takes arguments in the standard format x,y so the longitude must be specified before the latitude.
-There are limits to the coordinates that can be indexed: areas very near to the poles are not indexable.
+There are limits to the coordinates that can be indexed: areas very near to the poles are not index-able.
 
 ## GEOADD options
 
-GEOADD also provides the following options:
+`GEOADD` also provides the following options:
 
-- **XX**: Only update elements that already exist. Never add elements.
-- **NX**: Don't update already existing elements. Always add new elements.
-- **CH**: Modify the return value from the number of new elements added, to the total number of elements changed (CH is an abbreviation of changed).
+- `XX` -- Only update elements that already exist. Never add elements.
+- `NX` -- Don't update already existing elements. Always add new elements.
+- `CH` -- Modify the return value from the number of new elements added, to the total number of elements changed (CH is an abbreviation of changed).
 Changed elements are new elements added and elements already existing for which the coordinates were updated.
 So elements specified in the command line having the same score as they had in the past are not counted.
-Normally, the return value of GEOADD only counts the number of new elements added.
+Normally, the return value of `GEOADD` only counts the number of new elements added.
 
-Note: The **XX** and **NX** options are mutually exclusive.
+Note: The `XX` and `NX` options are mutually exclusive.
 
 ## Return
 
 [Integer reply](https://redis.io/docs/reference/protocol-spec/#resp-integers), specifically:
 
 - When used without optional arguments, the number of elements added to the sorted set (excluding score updates).
-- If the CH option is specified, the number of elements that were changed (added or updated).
+- If the `CH` option is specified, the number of elements that were changed (added or updated).
 
 ## Examples
 

--- a/docs/command-reference/geospatial-indices/geoadd.md
+++ b/docs/command-reference/geospatial-indices/geoadd.md
@@ -1,0 +1,46 @@
+---
+description: Add one or more geospatial items (longitude, latitude, name) to a geospatial index
+---
+
+# GEOADD
+
+## Syntax
+
+    GEOADD key [NX | XX] [CH] longitude latitude member [longitude latitude member ...]
+
+**Time complexity:** O(log(N)) for each item added, where N is the number of elements in the sorted set.
+
+Adds the specified geospatial items (longitude, latitude, name) to the specified key.
+Data is stored into the key as a sorted set, in a way that makes it possible to query the items with the `GEOSEARCH` command.
+
+The command takes arguments in the standard format x,y so the longitude must be specified before the latitude.
+There are limits to the coordinates that can be indexed: areas very near to the poles are not indexable.
+
+## GEOADD options
+
+GEOADD also provides the following options:
+
+- **XX**: Only update elements that already exist. Never add elements.
+- **NX**: Don't update already existing elements. Always add new elements.
+- **CH**: Modify the return value from the number of new elements added, to the total number of elements changed (CH is an abbreviation of changed).
+Changed elements are new elements added and elements already existing for which the coordinates were updated.
+So elements specified in the command line having the same score as they had in the past are not counted.
+Normally, the return value of GEOADD only counts the number of new elements added.
+
+Note: The **XX** and **NX** options are mutually exclusive.
+
+## Return
+
+[Integer reply](https://redis.io/docs/reference/protocol-spec/#resp-integers), specifically:
+
+- When used without optional arguments, the number of elements added to the sorted set (excluding score updates).
+- If the CH option is specified, the number of elements that were changed (added or updated).
+
+## Examples
+
+```shell
+dragonfly> GEOADD Sicily 13.361389 38.115556 "Palermo" 15.087269 37.502669 "Catania"
+(integer) 2
+dragonfly> GEODIST Sicily Palermo Catania
+"166274.1516"
+```

--- a/docs/command-reference/geospatial-indices/geodist.md
+++ b/docs/command-reference/geospatial-indices/geodist.md
@@ -1,0 +1,47 @@
+---
+description: Get the distance between two members in a geospatial index
+---
+
+# GEODIST
+
+## Syntax
+
+    GEODIST key member1 member2 [M | KM | FT | MI]
+
+**Time complexity:** O(log(N)), where N is the number of elements in the geospatial index represented by a sorted set.
+
+Return the distance between two members in the geospatial index represented by the sorted set.
+
+Given a sorted set representing a geospatial index, populated using the GEOADD command, the command returns the distance between the two specified members in the specified unit.
+
+If one or both the members are missing, the command returns NULL.
+
+The unit must be one of the following, and defaults to meters:
+
+- **m** for meters.
+- **km** for kilometers.
+- **mi** for miles.
+- **ft** for feet.
+
+The distance is computed assuming that the Earth is a perfect sphere, so errors up to 0.5% are possible in edge cases.
+
+## Return
+
+[Bulk string reply](https://redis.io/docs/reference/protocol-spec/#resp-bulk-strings), specifically:
+
+The command returns the distance as a double (represented as a string) in the specified unit, or NULL if one or both the elements are missing.
+
+## Examples
+
+```shell
+dragonfly> GEOADD Sicily 13.361389 38.115556 "Palermo" 15.087269 37.502669 "Catania"
+(integer) 2
+dragonfly> GEODIST Sicily Palermo Catania
+"166274.1516"
+dragonfly> GEODIST Sicily Palermo Catania km
+"166.2742"
+dragonfly> GEODIST Sicily Palermo Catania mi
+"103.3182"
+dragonfly> GEODIST Sicily Foo Bar
+(nil)
+```

--- a/docs/command-reference/geospatial-indices/geodist.md
+++ b/docs/command-reference/geospatial-indices/geodist.md
@@ -8,7 +8,7 @@ description: Get the distance between two members in a geospatial index
 
     GEODIST key member1 member2 [M | KM | FT | MI]
 
-**Time complexity:** O(log(N)), where N is the number of elements in the geospatial index represented by a sorted set.
+**Time complexity:** O(log(N)), where N is the number of elements in the geospatial index represented by the sorted set.
 
 Return the distance between two members in the geospatial index represented by the sorted set.
 

--- a/docs/command-reference/geospatial-indices/geodist.md
+++ b/docs/command-reference/geospatial-indices/geodist.md
@@ -12,7 +12,7 @@ description: Get the distance between two members in a geospatial index
 
 Return the distance between two members in the geospatial index represented by the sorted set.
 
-Given a sorted set representing a geospatial index, populated using the GEOADD command, the command returns the distance between the two specified members in the specified unit.
+Given a sorted set representing a geospatial index, populated using the [GEOADD](geoadd) command, the command returns the distance between the two specified members in the specified unit.
 
 If one or both the members are missing, the command returns NULL.
 

--- a/docs/command-reference/geospatial-indices/geodist.md
+++ b/docs/command-reference/geospatial-indices/geodist.md
@@ -12,16 +12,16 @@ description: Get the distance between two members in a geospatial index
 
 Return the distance between two members in the geospatial index represented by the sorted set.
 
-Given a sorted set representing a geospatial index, populated using the [GEOADD](geoadd) command, the command returns the distance between the two specified members in the specified unit.
+Given a sorted set representing a geospatial index, populated using the [`GEOADD`](geoadd) command, the command returns the distance between the two specified members in the specified unit.
 
 If one or both the members are missing, the command returns NULL.
 
 The unit must be one of the following, and defaults to meters:
 
-- **m** for meters.
-- **km** for kilometers.
-- **mi** for miles.
-- **ft** for feet.
+- `m` for meters.
+- `km` for kilometers.
+- `mi` for miles.
+- `ft` for feet.
 
 The distance is computed assuming that the Earth is a perfect sphere, so errors up to 0.5% are possible in edge cases.
 

--- a/docs/command-reference/geospatial-indices/geohash.md
+++ b/docs/command-reference/geospatial-indices/geohash.md
@@ -1,0 +1,39 @@
+---
+description: Get the Geohash strings of specified members in a geospatial index
+---
+
+# GEOHASH
+
+## Syntax
+
+    GEOHASH key [member [member ...]]
+
+**Time complexity:** O(log(N)) for each member requested, where N is the number of elements in the geospatial index represented by the sorted set.
+
+Return valid [Geohash](https://en.wikipedia.org/wiki/Geohash) strings representing the position of one or more elements
+in a sorted set value representing a geospatial index (where elements were added using [GEOADD](geoadd)).
+
+## Geohash string properties
+
+The command returns 11 characters Geohash strings, so no precision is lost compared to the Dragonfly internal 52 bit representation.
+The returned Geohashes have the following properties:
+
+- They can be shortened removing characters from the right. It will lose precision but will still point to the same area.
+- It is possible to use them in `geohash.org` URLs such as `http://geohash.org/<geohash-string>`.
+- Strings with a similar prefix are nearby, but the contrary is not true, it is possible that strings with different prefixes are nearby too.
+
+## Return
+
+[Array reply](https://redis.io/docs/reference/protocol-spec/#resp-arrays), specifically:
+
+The command returns an array where each element is the Geohash corresponding to each member name passed as argument to the command.
+
+## Examples
+
+```shell
+dragonfly> GEOADD Sicily 13.361389 38.115556 "Palermo" 15.087269 37.502669 "Catania"
+(integer) 2
+dragonfly> GEOHASH Sicily Palermo Catania
+1) "sqc8b49rny0"
+2) "sqdtr74hyu0"
+```

--- a/docs/command-reference/geospatial-indices/geohash.md
+++ b/docs/command-reference/geospatial-indices/geohash.md
@@ -11,7 +11,7 @@ description: Get the Geohash strings of specified members in a geospatial index
 **Time complexity:** O(log(N)) for each member requested, where N is the number of elements in the geospatial index represented by the sorted set.
 
 Return valid [Geohash](https://en.wikipedia.org/wiki/Geohash) strings representing the position of one or more elements
-in a sorted set value representing a geospatial index (where elements were added using [GEOADD](geoadd)).
+in a sorted set value representing a geospatial index (where elements were added using [`GEOADD`](geoadd)).
 
 ## Geohash string properties
 

--- a/docs/command-reference/geospatial-indices/geopos.md
+++ b/docs/command-reference/geospatial-indices/geopos.md
@@ -12,8 +12,8 @@ description: Get the positions of specified members in a geospatial index
 
 Return the positions (longitude,latitude) of all the specified members of the geospatial index represented by the sorted set.
 
-Given a sorted set representing a geospatial index, populated using the GEOADD command, it is often useful to obtain back the coordinates of specified members.
-When the geospatial index is populated via GEOADD the coordinates are converted into a 52 bit geohash,
+Given a sorted set representing a geospatial index, populated using the [GEOADD](geoadd) command, it is often useful to obtain back the coordinates of specified members.
+When the geospatial index is populated via [GEOADD](geoadd) the coordinates are converted into a 52 bit geohash,
 so the coordinates returned may not be exactly the ones used in order to add the elements, but small errors may be introduced.
 
 The command can accept a variable number of arguments, so it always returns an array of positions even when a single element is specified.

--- a/docs/command-reference/geospatial-indices/geopos.md
+++ b/docs/command-reference/geospatial-indices/geopos.md
@@ -10,10 +10,10 @@ description: Get the positions of specified members in a geospatial index
 
 **Time complexity:** O(N) where N is the number of members requested.
 
-Return the positions (longitude,latitude) of all the specified members of the geospatial index represented by the sorted set.
+Return the positions (longitude, latitude) of all the specified members of the geospatial index represented by the sorted set.
 
-Given a sorted set representing a geospatial index, populated using the [GEOADD](geoadd) command, it is often useful to obtain back the coordinates of specified members.
-When the geospatial index is populated via [GEOADD](geoadd) the coordinates are converted into a 52 bit geohash,
+Given a sorted set representing a geospatial index, populated using the [`GEOADD`](geoadd) command, it is often useful to obtain back the coordinates of specified members.
+When the geospatial index is populated via [`GEOADD`](geoadd) the coordinates are converted into a 52 bit Geohash,
 so the coordinates returned may not be exactly the ones used in order to add the elements, but small errors may be introduced.
 
 The command can accept a variable number of arguments, so it always returns an array of positions even when a single element is specified.

--- a/docs/command-reference/geospatial-indices/geopos.md
+++ b/docs/command-reference/geospatial-indices/geopos.md
@@ -1,0 +1,40 @@
+---
+description: Get the positions of specified members in a geospatial index
+---
+
+# GEOPOS
+
+## Syntax
+
+    GEOPOS key [member [member ...]]
+
+**Time complexity:** O(N) where N is the number of members requested.
+
+Return the positions (longitude,latitude) of all the specified members of the geospatial index represented by the sorted set.
+
+Given a sorted set representing a geospatial index, populated using the GEOADD command, it is often useful to obtain back the coordinates of specified members.
+When the geospatial index is populated via GEOADD the coordinates are converted into a 52 bit geohash,
+so the coordinates returned may not be exactly the ones used in order to add the elements, but small errors may be introduced.
+
+The command can accept a variable number of arguments, so it always returns an array of positions even when a single element is specified.
+
+## Return
+
+[Array reply](https://redis.io/docs/reference/protocol-spec/#resp-arrays), specifically:
+
+The command returns an array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command.
+
+Non-existing elements are reported as NULL elements of the array.
+
+## Examples
+
+```shell
+dragonfly> GEOADD Sicily 13.361389 38.115556 "Palermo" 15.087269 37.502669 "Catania"
+(integer) 2
+dragonfly> GEOPOS Sicily Palermo Catania NonExisting
+1) 1) "13.36138933897018433"
+   2) "38.11555639549629859"
+2) 1) "15.08726745843887329"
+   2) "37.50266842333162032"
+3) (nil)
+```

--- a/docs/command-reference/stream/_category_.yml
+++ b/docs/command-reference/stream/_category_.yml
@@ -1,5 +1,4 @@
 position: 10
-label: Stream
+label: Streams
 link:
   type: generated-index
-


### PR DESCRIPTION
Add the first batch of GEO commands described here: https://github.com/dragonflydb/documentation/issues/124
- `GEOADD`
- `GEOHASH`
- `GEODIST`
- `GEOPOS`

As for `GEOADD`, I didn't bring in the limits & Earth model sections from [here](https://redis.io/commands/geoadd/), since I need to confirm these with an engineer to make sure they are accurate for Dragonfly as well. However, for tomorrow's release, the current version should be sufficient, IMO. @worldsoup 