### PR TITLE
fix: GitHub stars link to dragonfly instead of documentation

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -122,7 +122,7 @@ const config = {
             target: "_self",
           },
           {
-            href: "https://github.com/dragonflydb/documentation/",
+            href: "https://github.com/dragonflydb/dragonfly",
             className: "nav-github-stars",
             position: "right",
           },


### PR DESCRIPTION
- Currently the GitHub stars (on the `/docs` page) links to this repo.
- Since it says 21k stars, it should link to the `dragonflydb/dragonfly` repo.