### PR TITLE
feat(stream): add docs for XCLAIM & XPENDING

### DIFF
--- a/docs/command-reference/compatibility.md
+++ b/docs/command-reference/compatibility.md
@@ -251,7 +251,7 @@ sidebar_position: 0
 |                                              | <span class="command">XCLAIM</span>                        | TBD                                                      |
 |                                              | <span class="command">XREAD</span>                         | <span class="support supported">Fully supported</span>   |
 |                                              | <span class="command">XADD</span>                          | <span class="support supported">Fully supported</span>   |
-|                                              | <span class="command">XPENDING</span>                      | TBD                                                      |
+|                                              | <span class="command">XPENDING</span>                      | <span class="support supported">Fully supported</span>   |
 |                                              | <span class="command">XGROUP</span>                        | <span class="support partial">Partially supported</span> |
 |                                              | <span class="command">XRANGE</span>                        | <span class="support supported">Fully supported</span>   |
 |                                              | <span class="command">XSETID</span>                        | <span class="support supported">Fully supported</span>   |

--- a/docs/command-reference/compatibility.md
+++ b/docs/command-reference/compatibility.md
@@ -248,7 +248,7 @@ sidebar_position: 0
 |                                              | <span class="command">ZUNION</span>                        | <span class="support supported">Fully supported</span>   |
 |                                              | <span class="command">ZUNIONSTORE</span>                   | <span class="support supported">Fully supported</span>   |
 | <span class="family">Stream</span>           | <span class="command">XAUTOCLAIM</span>                    | <span class="support unsupported">Unsupported</span>     |
-|                                              | <span class="command">XCLAIM</span>                        | TBD                                                      |
+|                                              | <span class="command">XCLAIM</span>                        | <span class="support partial">Partially supported</span> |
 |                                              | <span class="command">XREAD</span>                         | <span class="support supported">Fully supported</span>   |
 |                                              | <span class="command">XADD</span>                          | <span class="support supported">Fully supported</span>   |
 |                                              | <span class="command">XPENDING</span>                      | <span class="support supported">Fully supported</span>   |

--- a/docs/command-reference/stream/xclaim.md
+++ b/docs/command-reference/stream/xclaim.md
@@ -3,3 +3,98 @@ description: Change the ownership of a pending message within a stream consumer 
 ---
 
 # XCLAIM
+
+## Syntax
+
+	XCLAIM key group consumer min-idle-time id [id ...] [IDLE ms]
+      [TIME unix-time-milliseconds] [RETRYCOUNT count] [FORCE] [JUSTID]
+      [LASTID lastid]
+
+**Time Complexity:** O(log N) with N being the number of messages in the PEL of the consumer group.
+
+**ACL categories:** @write, @stream, @fast
+
+In the context of a stream consumer group, this command changes the ownership of a pending message, so that the new owner is the consumer specified as the command argument.
+Normally this is what happens:
+
+1. There is a stream with an associated consumer group.
+2. Some consumer A reads a message via `XREADGROUP` from a stream, in the context of that consumer group.
+3. As a side effect a pending message entry is created in the Pending Entries List (PEL) of the consumer group:
+   it means the message was delivered to a given consumer, but it was not yet acknowledged via `XACK`.
+4. Then suddenly that consumer fails forever.
+5. Other consumers may inspect the list of pending messages, that are stale for quite some time, using the [`XPENDING`](./xpending.md) command.
+   In order to continue processing such messages, they use `XCLAIM` to acquire the ownership of the message and continue.
+   Consumers can also use the `XAUTOCLAIM` command to automatically scan and claim stale pending messages.
+
+You can learn more about Streams [here](https://redis.io/docs/data-types/streams/).
+
+Note that the message is claimed only if its idle time is greater than the minimum idle time we specify when calling `XCLAIM`.
+Because as a side effect, `XCLAIM` will also reset the idle time (since this is a new attempt at processing the message),
+two consumers trying to claim a message at the same time will never both succeed: only one will successfully claim the message.
+This avoids that we process a given message multiple times in a trivial way (yet multiple processing is possible and unavoidable in the general case).
+
+Moreover, as a side effect, `XCLAIM` will increment the count of attempted deliveries of the message unless the `JUSTID` option has been specified (which only delivers the message ID, not the message itself).
+In this way messages that cannot be processed for some reason, for instance because the consumers crash attempting to process them, will start to have a larger counter and can be detected inside the system.
+
+`XCLAIM` will not claim a message in the following cases:
+
+1. The message doesn't exist in the group PEL (i.e. it was never read by any consumer)
+2. The message exists in the group PEL but not in the stream itself (i.e. the message was read but never acknowledged, and then was deleted from the stream, either by trimming or by `XDEL`)
+
+In both cases the reply will not contain a corresponding entry to that message (i.e. the length of the reply array may be smaller than the number of IDs provided to `XCLAIM`).
+In the latter case, the message will also be deleted from the PEL in which it was found.
+
+## Command Options
+
+The command has multiple options, however most are mainly for internal use in order to transfer the effects of `XCLAIM` or other commands
+to the AOF file and to propagate the same effects to the replicas, and are unlikely to be useful to normal users:
+
+1. `IDLE <ms>`: Set the idle time (last time it was delivered) of the message.
+   If `IDLE` is not specified, an `IDLE` of 0 is assumed, that is, the time count is reset because the message has now a new owner trying to process it.
+2. `TIME <ms-unix-time>`: This is the same as `IDLE` but instead of a relative amount of milliseconds, it sets the idle time to a specific Unix time (in milliseconds).
+   This is useful in order to rewrite the AOF file generating `XCLAIM` commands.
+3. `RETRYCOUNT <count>`: Set the retry counter to the specified value. This counter is incremented every time a message is delivered again.
+   Normally `XCLAIM` does not alter this counter, which is just served to clients when the [`XPENDING`](./xpending.md) command is called:
+   this way clients can detect anomalies, like messages that are never processed for some reason after a big number of delivery attempts.
+4. `FORCE`: Creates the pending message entry in the PEL even if certain specified IDs are not already in the PEL assigned to a different client.
+   However, the message must exist in the stream, otherwise the IDs of non-existing messages are ignored. 
+5. `JUSTID`: Return just an array of IDs of messages successfully claimed, without returning the actual message.
+   Using this option means the retry counter is not incremented.
+6. `LASTID`: Not supported yet.
+
+## Return
+
+[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays), specifically:
+
+- The command returns all the messages successfully claimed, in the same format as [`XRANGE`](./xrange.md).
+- However, if the `JUSTID` option was specified, only the message IDs are reported, without including the actual message.
+
+## Examples
+
+```shell
+dragonfly> XADD mystream * name Alice surname Adams
+"1695755830453-0"
+
+dragonfly> XADD mystream * name John surname Doe
+"1695755847112-0"
+
+dragonfly> XGROUP CREATE mystream mygroup 0-0
+OK
+
+dragonfly> XREADGROUP GROUP mygroup consumer-123 COUNT 1 STREAMS mystream >
+1) 1) "mystream"
+   2) 1) 1) "1695755830453-0"
+         2) 1) "name"
+            2) "Alice"
+            3) "surname"
+            4) "Adams"
+```
+
+```shell
+dragonfly> XCLAIM mystream mygroup consumer-345 10000 1695755830453-0
+1) 1) "1695755830453-0"
+   2) 1) "name"
+      2) "Alice"
+      3) "surname"
+      4) "Adams"
+```

--- a/docs/command-reference/stream/xclaim.md
+++ b/docs/command-reference/stream/xclaim.md
@@ -1,0 +1,5 @@
+---
+description: Change the ownership of a pending message within a stream consumer group
+---
+
+# XCLAIM

--- a/docs/command-reference/stream/xpending.md
+++ b/docs/command-reference/stream/xpending.md
@@ -1,0 +1,142 @@
+---
+description: Fetch data from a stream via a consumer group, and not acknowledging such data
+---
+
+# XPENDING
+
+## Syntax
+
+	XPENDING key group [[IDLE min-idle-time] start end count [consumer]]
+
+**Time Complexity:** O(N) with N being the number of elements returned, so asking for a small fixed number of entries per call is O(1).
+O(M), where M is the total number of entries scanned when used with the IDLE filter.
+When the command returns just the summary and the list of consumers is small, it runs in O(1) time; otherwise, an additional O(N) time for iterating every consumer.
+
+**ACL categories:** @read, @stream, @slow
+
+Fetching data from a stream via a consumer group, and not acknowledging such data, has the effect of creating pending entries.
+This is well explained in the `XREADGROUP` command.
+You can also learn more about Streams [here](https://redis.io/docs/data-types/streams/).
+
+The `XACK` command will immediately remove the pending entry from the Pending Entries List (PEL) since once a message is successfully processed,
+there is no longer need for the consumer group to track it and to remember the current owner of the message.
+
+The `XPENDING` command is the interface to inspect the list of pending messages,
+and is as thus a very important command in order to observe and understand what is happening with a streams consumer groups:
+what clients are active, what messages are pending to be consumed, or to see if there are idle messages.
+Moreover, this command, together with [`XCLAIM`](./xclaim.md) is used in order to implement recovering of consumers that are failing for a long time,
+and as a result certain messages are not processed: a different consumer can claim the message and continue.
+
+## Summary Form
+
+When `XPENDING` is called with just a key name and a consumer group name, it just returns output in the **summary form** about the pending messages in a given consumer group.
+In the following example, we create a consumer group and immediately create a pending message by reading from the group with `XREADGROUP`.
+
+```shell
+dragonfly> XADD mystream * name Alice surname Adams
+"1695755830453-0"
+
+dragonfly> XADD mystream * name John surname Doe
+"1695755847112-0"
+
+dragonfly> XGROUP CREATE mystream mygroup 0-0
+OK
+
+dragonfly> XREADGROUP GROUP mygroup consumer-123 COUNT 1 STREAMS mystream >
+1) 1) "mystream"
+   2) 1) 1) "1695755830453-0"
+         2) 1) "name"
+            2) "Alice"
+            3) "surname"
+            4) "Adams"
+```
+
+We expect the pending entries list for the consumer group `mygroup` to have a message right now: consumer named `consumer-123` fetched the message without acknowledging its processing.
+The simple summary form of `XPENDING` will give us this information:
+
+```shell
+dragonfly> XPENDING mystream mygroup
+1) (integer) 1
+2) "1695755830453-0"
+3) "1695755830453-0"
+4) 1) 1) "consumer-123"
+      2) (integer) 1
+```
+
+In this form, the command outputs the total number of pending messages for this consumer group, which is one, followed by the smallest and greatest ID among the pending messages,
+and then list every consumer in the consumer group with at least one pending message, and the number of pending messages it has.
+
+## Extended Form
+
+The summary form provides a good overview, but sometimes we are interested in the details.
+In order to see all the pending messages, in the **extended form**, with more associated information we need to also pass a range of IDs, in a similar way we do it with [`XRANGE`](./xrange.md) ,
+and a non-optional count argument, to limit the number of messages returned per call:
+
+```shell
+dragonfly> XPENDING mystream mygroup - + 10
+1) 1) "1695755830453-0"
+   2) "consumer-123"
+   3) (integer) 1257837
+   4) (integer) 1
+```
+
+In the extended form we no longer see the summary information, instead there is detailed information for each message in the pending entries list.
+For each message four attributes are returned:
+
+1. The ID of the message.
+2. The current owner of the message (i.e., the consumer that fetched the message and has still to acknowledge it).
+3. The number of milliseconds that elapsed since the last time this message was delivered to this consumer. 
+4. The number of times this message was delivered.
+
+The deliveries counter, that is the fourth element in the array, is incremented when some other consumer claims the message with [`XCLAIM`](./xclaim.md)
+or when the message is delivered again via `XREADGROUP`, when accessing the history of a consumer in a consumer group.
+
+It is possible to pass an additional argument to the command, in order to see the messages having a specific owner:
+
+```shell
+dragonfly> XPENDING mystream mygroup - + 10 consumer-123
+```
+
+But in the above case the output would be the same, since we have pending messages only for a single consumer `consumer-123`.
+However, what is important to keep in mind is that this operation, filtering by a specific consumer, is not inefficient even when there are many pending messages from many consumers:
+we have a pending entries list data structure both globally, and for every consumer, so we can very efficiently show just messages pending for a single consumer.
+
+## Idle Time Filter
+
+It is also possible to filter pending stream entries by their idle-time, given in milliseconds (useful for [`XCLAIM`](./xclaim.md)ing entries that have not been processed for some time):
+
+```shell
+dragonfly> XPENDING mystream mygroup IDLE 9000 - + 10
+dragonfly> XPENDING mystream mygroup IDLE 9000 - + 10 consumer-123
+```
+
+The first case will return the first 10 (or less) PEL entries of the entire group that are idle for over 9 seconds, whereas in the second case only those of `consumer-123`.
+
+## Pending Entries List & Exclusive Ranges
+
+The `XPENDING` command allows iterating over the Pending Entries List (PEL) just like [`XRANGE`](./xrange.md) and [`XREVRANGE`](./xrevrange.md) allow for the stream's entries.
+You can do this by prefixing the ID of the last-read pending entry with the `(` character that denotes an open (exclusive) range, and proving it to the subsequent call to the command.
+
+By default, the command returns entries including specified IDs:
+
+```shell
+dragonfly> XPENDING mystream mygroup 1695755830453-0 + 10
+1) 1) "1695755830453-0"
+   2) "consumer-123"
+   3) (integer) 1577015
+   4) (integer) 1
+```
+
+If the ID is prefixed with `(`, the range is exclusive:
+
+```shell
+dragonfly> XPENDING mystream mygroup (1695755830453-0 + 10
+(empty array)
+```
+
+## Return
+
+[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays), specifically:
+
+- The command returns data in different format depending on the way it is called, as previously explained in this page.
+- However, the reply is always an array of items.

--- a/docs/command-reference/stream/xpending.md
+++ b/docs/command-reference/stream/xpending.md
@@ -1,5 +1,5 @@
 ---
-description: Fetch data from a stream via a consumer group, and not acknowledging such data
+description: Get info and entries from a consumer group pending entries list
 ---
 
 # XPENDING


### PR DESCRIPTION
- https://github.com/dragonflydb/documentation/issues/151 & https://github.com/dragonflydb/documentation/issues/152
- Pulled in docs for `XCLAIM` & `XPENDING`.
- Made adjustments according to Dragonfly server behavior.
- Please use the preview site if that's easier.