### PR TITLE
Adding doc for new STREAM commands and options

### DIFF
--- a/docs/command-reference/compatibility.md
+++ b/docs/command-reference/compatibility.md
@@ -247,20 +247,20 @@ sidebar_position: 0
 |                                              | <span class="command">ZSCORE</span>                        | <span class="support supported">Fully supported</span>   |
 |                                              | <span class="command">ZUNION</span>                        | <span class="support supported">Fully supported</span>   |
 |                                              | <span class="command">ZUNIONSTORE</span>                   | <span class="support supported">Fully supported</span>   |
-| <span class="family">Stream</span>           | <span class="command">XAUTOCLAIM</span>                    | <span class="support unsupported">Unsupported</span>     |
-|                                              | <span class="command">XCLAIM</span>                        | <span class="support partial">Partially supported</span> |
+| <span class="family">Stream</span>           | <span class="command">XAUTOCLAIM</span>                    | <span class="support supported">Fully supported</span>     |
+|                                              | <span class="command">XCLAIM</span>                        | <span class="support supported">Fully supported</span> |
 |                                              | <span class="command">XREAD</span>                         | <span class="support supported">Fully supported</span>   |
 |                                              | <span class="command">XADD</span>                          | <span class="support supported">Fully supported</span>   |
 |                                              | <span class="command">XPENDING</span>                      | <span class="support supported">Fully supported</span>   |
-|                                              | <span class="command">XGROUP</span>                        | <span class="support partial">Partially supported</span> |
+|                                              | <span class="command">XGROUP</span>                        | <span class="support supported">Fully supported</span> |
 |                                              | <span class="command">XRANGE</span>                        | <span class="support supported">Fully supported</span>   |
 |                                              | <span class="command">XSETID</span>                        | <span class="support supported">Fully supported</span>   |
 |                                              | <span class="command">XREVRANGE</span>                     | <span class="support supported">Fully supported</span>   |
-|                                              | <span class="command">XREADGROUP</span>                    | <span class="support unsupported">Unsupported</span>     |
+|                                              | <span class="command">XREADGROUP</span>                    | <span class="support supported">Fully supported</span>     |
 |                                              | <span class="command">XDEL</span>                          | <span class="support supported">Fully supported</span>   |
 |                                              | <span class="command">XINFO</span>                         | <span class="support partial">Partially supported</span> |
-|                                              | <span class="command">XACK</span>                          | <span class="support unsupported">Unsupported</span>     |
-|                                              | <span class="command">XTRIM</span>                         | <span class="support partial">Partially supported</span> |
+|                                              | <span class="command">XACK</span>                          | <span class="support supported">Fully supported</span>     |
+|                                              | <span class="command">XTRIM</span>                         | <span class="support supported">Fully supported</span> |
 | <span class="family">String</span>           | <span class="command">APPEND</span>                        | <span class="support supported">Fully supported</span>   |
 |                                              | <span class="command">DECR</span>                          | <span class="support supported">Fully supported</span>   |
 |                                              | <span class="command">DECRBY</span>                        | <span class="support supported">Fully supported</span>   |

--- a/docs/command-reference/stream/xack.md
+++ b/docs/command-reference/stream/xack.md
@@ -1,0 +1,29 @@
+---
+description: Acknowledge a received message and removes the message from consumer group's pending entries list.
+---
+
+# XACK
+
+## Syntax
+
+    XACK key group id [id ... ]
+
+**Time complexity:** O(1) for each message ID processed.
+
+**ACL categories:** @write, @stream, @fast
+
+**XACK** command acknowledges one or more messages by removing the messages from the pending entries list (PEL) of the specified consumer stream group. A message is pending, and as such stored inside the PEL, when it was delivered to some consumer, normally as a side effect of calling XREADGROUP, or when a consumer took ownership of a message calling XCLAIM. The pending message was delivered to some consumer but the server is yet not sure it was processed at least once. So new calls to XREADGROUP to grab the messages history for a consumer (for instance using an ID of 0), will return such message. Similarly the pending message will be listed by the XPENDING command, that inspects the PEL. Once a consumer successfully processes a message, it should call **XACK** so that such message does not get processed again, and as a side effect, the PEL entry about this message is also purged, releasing memory from the Dragonfly server.
+
+
+## Return
+
+[Integer reply](https://redis.io/docs/reference/protocol-spec/#resp-integers), specifically:
+
+The command returns the number of messages successfully acknowledged. Certain message IDs may no longer be part of the PEL (for example because they have already been acknowledged), and XACK will not count them as successfully acknowledged.
+
+## Examples
+
+```shell
+dragonfly> XACK mystream mygroup 1526569495631-0
+(integer) 1
+```

--- a/docs/command-reference/stream/xautoclaim.md
+++ b/docs/command-reference/stream/xautoclaim.md
@@ -1,0 +1,55 @@
+---
+description: Change the ownership of pending stream entries that match the specified criteria.
+---
+
+# XAUTOCLAIM
+
+## Syntax
+
+    XAUTOCLAIM key group consumer min-idle-time start [COUNT count] [JUSTID]
+
+**Time Complexity:** O(1) if COUNT is small.
+
+**ACL categories:** @write, @stream, @fast
+
+This command transfers ownership of pending stream entries that match the specified criteria. Conceptually, `XAUTOCLAIM` is equivalent to calling `XPENDING` and then `XCLAIM`, but provides a more straightforward way to deal with message delivery failures via SCAN-like semantics.
+
+Like `XCLAIM`, the command operates on the stream entries at `<key>` and in the context of the provided `<group>`. It transfers ownership to `<consumer>` of messages pending for more than `<min-idle-time>` milliseconds and having an equal or greater ID than `<start>`.
+
+The optional `<count>` argument, which defaults to 100, is the upper limit of the number of entries that the command attempts to claim. Internally, the command begins scanning the consumer group's Pending Entries List (PEL) from `<start>` and filters out entries having an idle time less than or equal to `<min-idle-time>`. The maximum number of pending entries that the command scans is the product of multiplying `<count>`'s value by 10 (hard-coded). It is possible, therefore, that the number of entries claimed will be less than the specified value.
+
+The optional `JUSTID` argument changes the reply to return just an array of IDs of messages successfully claimed, without returning the actual message. Using this option means the retry counter is not incremented.
+
+The command returns the claimed entries as an array. It also returns a stream ID intended for cursor-like use as the `<start>` argument for its subsequent call. When there are no remaining PEL entries, the command returns the special `0-0` ID to signal completion. However, note that you may want to continue calling `XAUTOCLAIM` even after the scan is complete with the `0-0` as `<start>` ID, because enough time passed, so older pending entries may now be eligible for claiming.
+
+Note that only messages that are idle longer than `<min-idle-time>` are claimed, and claiming a message resets its idle time. This ensures that only a single consumer can successfully claim a given pending message at a specific instant of time and trivially reduces the probability of processing the same message multiple times.
+
+While iterating the PEL, if `XAUTOCLAIM` stumbles upon a message which doesn't exist in the stream anymore (either trimmed or deleted by `XDEL`) it does not claim it, and deletes it from the PEL in which it was found. These message IDs are returned to the caller as a part of `XAUTOCLAIM`'s reply.
+
+Lastly, claiming a message with `XAUTOCLAIM` also increments the attempted deliveries count for that message, unless the `JUSTID` option has been specified (which only delivers the message ID, not the message itself). Messages that cannot be processed for some reason - for example, because consumers systematically crash when processing them - will exhibit high attempted delivery counts that can be detected by monitoring.
+
+
+## Return
+
+[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays), specifically:
+
+An array with three elements:
+
+1. A stream ID to be used as the `<start>` argument for the next call to `XAUTOCLAIM.
+
+2. An array containing all the successfully claimed messages in the same format as `XRANGE`.
+
+3. An array containing message IDs that no longer exist in the stream, and were deleted from the PEL in which they were found.
+
+## Examples
+
+```shell
+dragonfly> XAUTOCLAIM mystream mygroup Alice 3600000 0-0 COUNT 25
+1) "0-0"
+2) 1) 1) "1609338752495-0"
+      2) 1) "field"
+         2) "value"
+3) (empty array)
+```
+
+In the above example, we attempt to claim for consumer `Alice` up to 25 entries that are pending and idle (not having been acknowledged or claimed) for at least an hour, starting at the stream's beginning. The consumer `Alice` from the `mygroup` group acquires ownership of these messages. Note that the stream ID returned in the example is `0-0`, indicating that the entire stream was scanned. We can also see that `XAUTOCLAIM did not stumble upon any deleted messages (the third reply element is an empty array).

--- a/docs/command-reference/stream/xclaim.md
+++ b/docs/command-reference/stream/xclaim.md
@@ -49,9 +49,9 @@ In the latter case, the message will also be deleted from the PEL in which it wa
 The command has multiple options, however most are mainly for internal use in order to transfer the effects of `XCLAIM` or other commands
 to the AOF file and to propagate the same effects to the replicas, and are unlikely to be useful to normal users:
 
-1. `IDLE <ms>` **(not supported yet)**: Set the idle time (last time it was delivered) of the message.
+1. `IDLE <ms>`: Set the idle time (last time it was delivered) of the message.
    If `IDLE` is not specified, an `IDLE` of 0 is assumed, that is, the time count is reset because the message has now a new owner trying to process it.
-2. `TIME <ms-unix-time>` **(not supported yet)**: This is the same as `IDLE` but instead of a relative amount of milliseconds, it sets the idle time to a specific Unix time (in milliseconds).
+2. `TIME <ms-unix-time>` : This is the same as `IDLE` but instead of a relative amount of milliseconds, it sets the idle time to a specific Unix time (in milliseconds).
    This is useful in order to rewrite the AOF file generating `XCLAIM` commands.
 3. `RETRYCOUNT <count>`: Set the retry counter to the specified value. This counter is incremented every time a message is delivered again.
    Normally `XCLAIM` does not alter this counter, which is just served to clients when the [`XPENDING`](./xpending.md) command is called:
@@ -60,7 +60,8 @@ to the AOF file and to propagate the same effects to the replicas, and are unlik
    However, the message must exist in the stream. Otherwise, the IDs of non-existing messages are ignored. 
 5. `JUSTID`: Return just an array of IDs of messages successfully claimed, without returning the actual message.
    Using this option means the retry counter is not incremented.
-6. `LASTID` **(not supported yet)**: More information about this option is yet to come.
+6. `LASTID` : Update the consumer group last ID with the specified ID if the current last ID is smaller than the provided one.
+
 
 ## Return
 


### PR DESCRIPTION
fixes https://github.com/dragonflydb/documentation/issues/160

New commands / options:
XACK
XCLAIM (new last_id option)
XAUTOCLAIM


