### PR TITLE
Rename pipeline_queue_limit to subscriber_thread_limit

### DIFF
--- a/docs/managing-dragonfly/flags.md
+++ b/docs/managing-dragonfly/flags.md
@@ -100,8 +100,8 @@ flags which include specified substring in either in the name, description or pa
 
   `default: false`
 
-### `--pipeline_queue_limit`
-  Amount of memory to use for storing pipelined commands in bytes - per IO thread.
+### `--subscriber_thread_limit`
+  Amount of memory to use for storing pub commands in bytes - per IO thread.
 
   `default: 134217728`
 


### PR DESCRIPTION
Just a very quick fix. The param name was updated in https://github.com/dragonflydb/dragonfly/pull/2192/files