### PR TITLE
feat: add Redlock & Relay

### DIFF
--- a/docs/command-reference/server-management/client-tracking.md
+++ b/docs/command-reference/server-management/client-tracking.md
@@ -1,0 +1,70 @@
+---
+description:  Learn how to use Redis CLIENT TRACKING command to control server-assisted client side caching for the connection.
+---
+
+import PageTitle from '@site/src/components/PageTitle';
+
+# CLIENT TRACKING
+
+<PageTitle title="Redis CLIENT TRACKING Command (Documentation) | Dragonfly" />
+
+## Syntax
+
+    CLIENT TRACKING <ON | OFF>
+
+**Time complexity:** O(1). Some options may introduce additional complexity.
+
+**ACL categories:** @slow, @connection
+
+**Important**: New in Dragonfly v1.14, only available when the [RESP3](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md) protocol is used.
+
+The `CLIENT TRACKING` command enables the tracking feature of the Dragonfly server, which is used for server-assisted client side caching.
+See more details about server-assisted client side caching in the [Redis documentation](https://redis.io/docs/manual/client-side-caching/).
+
+When tracking is enabled, Dragonfly remembers the keys that the connection requested in order to send later invalidation messages when such keys are modified.
+Invalidation messages are sent in the same connection when the RESP3 protocol is used.
+
+## Return
+
+[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): `OK` if the connection was
+successfully put in tracking mode or if the tracking mode was successfully disabled. Otherwise, an error is returned.
+
+## Examples
+
+Use two clients to connect to the Dragonfly server using the RESP3 protocol.
+Switching to the RESP3 protocol can be done with the `HELLO` command.
+Alternatively, clients or SDKs may have a configuration option to use the RESP3 protocol (i.e., `redis-cli -3`) upon connection.
+
+In the example below, the first client is put in tracking mode.
+When the second client updates a key, the first client will receive an invalidation message.
+Note that creating a non-existing key will not make Dragonfly track the key.
+A key must be read by the client to be tracked.
+
+```shell
+### client-1 ###
+
+# Switch protocol to RESP3, output omitted.
+dragonfly> HELLO 3
+
+# Create a key, set its value, and read it back.
+dragonfly> SET user_count 100
+OK
+dragonfly> GET user_count
+"100"
+
+# After client-2 updates the value, read the key again.
+dragonfly> GET user_count
+-> invalidate: 'user_count'
+"101"
+```
+
+```shell
+### client-2 ###
+
+# Switch protocol to RESP3, output omitted.
+dragonfly> HELLO 3
+
+# Now client-2 updates the value.
+dragonfly> INCR user_count
+(integer) 101
+```

--- a/docs/command-reference/server-management/client-tracking.md
+++ b/docs/command-reference/server-management/client-tracking.md
@@ -26,7 +26,8 @@ Invalidation messages are sent in the same connection when the RESP3 protocol is
 It is very important to note that **only when the client reads a key after enabling tracking will Dragonfly start tracking that key**.
 Solely creating a key will not make Dragonfly track the key. See the examples below for more details.
 
-When tracking is disabled, Dragonfly stops tracking the keys for the connection, and no invalidation messages are sent.
+The feature will remain active in the current connection for all its life, unless tracking is disabled with `CLIENT TRACKING OFF` at some point,
+and Dragonfly stops tracking the keys for the connection, and no invalidation messages are sent.
 
 ## Return
 
@@ -77,7 +78,8 @@ Back to `client-1` again, it reads the key (within the same session) and receive
 ```shell
 ### client-1 ###
 
-# After client-2 updates the value, client-1 reads the key again and receives an invalidation message.
+# After client-2 updates the value,
+# client-1 reads the key again and receives an invalidation message.
 dragonfly> GET user_count
 -> invalidate: 'user_count'
 "101"

--- a/docs/command-reference/server-management/client-tracking.md
+++ b/docs/command-reference/server-management/client-tracking.md
@@ -23,6 +23,10 @@ See more details about server-assisted client side caching in the [Redis documen
 
 When tracking is enabled, Dragonfly remembers the keys that the connection requested in order to send later invalidation messages when such keys are modified.
 Invalidation messages are sent in the same connection when the RESP3 protocol is used.
+It is very important to note that **only when the client reads a key after enabling tracking will Dragonfly start tracking that key**.
+Solely creating a key will not make Dragonfly track the key. See the examples below for more details.
+
+When tracking is disabled, Dragonfly stops tracking the keys for the connection, and no invalidation messages are sent.
 
 ## Return
 
@@ -32,13 +36,12 @@ successfully put in tracking mode or if the tracking mode was successfully disab
 ## Examples
 
 Use two clients to connect to the Dragonfly server using the RESP3 protocol.
-Switching to the RESP3 protocol can be done with the `HELLO` command.
+Switching to the RESP3 protocol can be done with the [`HELLO`](./hello.md) command.
 Alternatively, clients or SDKs may have a configuration option to use the RESP3 protocol (i.e., `redis-cli -3`) upon connection.
 
-In the example below, the first client is put in tracking mode.
-When the second client updates a key, the first client will receive an invalidation message.
+In the example below, `client-1` is put in tracking mode.
 Note that creating a non-existing key will not make Dragonfly track the key.
-A key must be read by the client to be tracked.
+Instead, the key must be read after tracking is enabled to start being tracked.
 
 ```shell
 ### client-1 ###
@@ -46,25 +49,36 @@ A key must be read by the client to be tracked.
 # Switch protocol to RESP3, output omitted.
 dragonfly> HELLO 3
 
-# Create a key, set its value, and read it back.
+# Switch on client tracking.
+dragonfly> CLIENT TRACKING ON
+OK
+
+# Create a key and set its value to 100.
 dragonfly> SET user_count 100
 OK
+
+# Read the key so that the server starts tracking its update.
 dragonfly> GET user_count
 "100"
-
-# After client-2 updates the value, read the key again.
-dragonfly> GET user_count
--> invalidate: 'user_count'
-"101"
 ```
+
+Now `client-2` makes an update on the key:
 
 ```shell
 ### client-2 ###
 
-# Switch protocol to RESP3, output omitted.
-dragonfly> HELLO 3
-
 # Now client-2 updates the value.
 dragonfly> INCR user_count
 (integer) 101
+```
+
+Back to `client-1` again, it reads the key (within the same session) and receives an invalidation message on the key:
+
+```shell
+### client-1 ###
+
+# After client-2 updates the value, client-1 reads the key again and receives an invalidation message.
+dragonfly> GET user_count
+-> invalidate: 'user_count'
+"101"
 ```

--- a/docs/integrations/bullmq.md
+++ b/docs/integrations/bullmq.md
@@ -101,6 +101,8 @@ By distributing the queues across distinct Dragonfly threads, you can optimize t
 If you have queue dependencies, especially a parent-child relationship, it's important to use the same hashtag for both queues.
 This ensures that they are processed within the same Dragonfly thread and maintains the integrity of the dependencies.
 
-## Useful Resources
+## Useful Resources & Benchmarks
 
 - BullMQ [Homepage](https://bullmq.io/), [GitHub](https://github.com/taskforcesh/bullmq), and [Documentation](https://docs.bullmq.io/).
+- Read our blog post [How We Optimized Dragonfly to Get 30x Throughput with BullMQ](https://www.dragonflydb.io/blog/running-bullmq-with-dragonfly-part-2-optimization)
+  with internal implementation details and performance benchmarks.

--- a/docs/integrations/clickhouse.md
+++ b/docs/integrations/clickhouse.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 2
+sidebar_position: 1
 description: ClickHouse
 ---
 

--- a/docs/integrations/feast.md
+++ b/docs/integrations/feast.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 3
+sidebar_position: 1
 description: Feast
 ---
 

--- a/docs/integrations/integrations.md
+++ b/docs/integrations/integrations.md
@@ -22,6 +22,7 @@ providing users with peace of mind and confidence in the stability and performan
 - [BullMQ](./bullmq.md): A premium job and message queue system for Node.js.
 - [ClickHouse](./clickhouse.md): A fast open-source column-oriented DBMS that allows generating analytical data reports in real time.
 - [Feast](./feast.md): A customizable feature store for operational machine learning.
+- [Redlock](./redlock.md): A distributed lock pattern with implementations in various languages.
 - [Sidekiq](./sidekiq.md): Simple and efficient background job processing for Ruby.
 
 ## Making the Switch

--- a/docs/integrations/integrations.md
+++ b/docs/integrations/integrations.md
@@ -19,10 +19,11 @@ Despite Dragonfly's promise of a seamless switch, the Dragonfly community invest
 Our commitment ensures that these projects are not just compatible but are officially supported,
 providing users with peace of mind and confidence in the stability and performance enhancements Dragonfly offers.
 
-- [BullMQ](./bullmq.md): A premium job and message queue system for Node.js.
-- [ClickHouse](./clickhouse.md): A fast open-source column-oriented DBMS that allows generating analytical data reports in real time.
-- [Feast](./feast.md): A customizable feature store for operational machine learning.
-- [Redlock](./redlock.md): A distributed lock pattern with implementations in various languages.
+- [BullMQ](./bullmq.md): Premium job and message queue system for Node.js.
+- [ClickHouse](./clickhouse.md): Ultra fast and resource efficient open-source database for real-time applications and analytics.
+- [Feast](./feast.md): Customizable feature store for operational machine learning written in Python.
+- [Redlock](./redlock.md): Distributed lock pattern with implementations in various languages.
+- [Relay](./relay.md): Next-generation shared in-memory caching layer for PHP.
 - [Sidekiq](./sidekiq.md): Simple and efficient background job processing for Ruby.
 
 ## Making the Switch

--- a/docs/integrations/redlock.md
+++ b/docs/integrations/redlock.md
@@ -11,10 +11,11 @@ description: Redlock
 distributed locks, ensuring consistent operation and protection against failures such as network partitions and Redis crashes.
 It operates by having a client application send lock requests, using [`SET`](../command-reference/strings/set.md) commands, to multiple **primary Redis instances**.
 The lock is successfully acquired when more than half of these instances agree on the lock acquisition.
-To release the lock, the client issues [`DEL`](../command-reference/generic/del.md) commands to all the instances involved.
+To release the lock, the client application uses a Lua script, which involves the [`GET`](../command-reference/strings/get.md) command
+and the [`DEL`](../command-reference/generic/del.md) command, to perform compare-and-delete operations on all the instances involved.
 Redlock also takes into account the lock validity time, retry on failure, lock extension, and many other aspects, which makes it a robust and reliable solution for distributed locking.
 
-Since Dragonfly is highly compatible with Redis and both `SET` and `DEL` commands are fully supported, Redlock implementations can be easily used with Dragonfly.
+Since Dragonfly is highly compatible with Redis, Redlock implementations can be easily used with Dragonfly.
 
 ## Implementations
 

--- a/docs/integrations/redlock.md
+++ b/docs/integrations/redlock.md
@@ -9,7 +9,7 @@ description: Redlock
 
 [Redlock](https://redis.io/docs/manual/patterns/distributed-locks/) is a recognized algorithm based on Redis for
 distributed locks, ensuring consistent operation and protection against failures such as network partitions and Redis crashes.
-It operates by having a client application send lock requests, using [`SET`](../command-reference/strings/set.md) commands, to multiple **primary Redis instances**.
+It operates by having a client application send lock requests, using [`SET`](../command-reference/strings/set.md) commands, to **multiple primary Redis instances**.
 The lock is successfully acquired when more than half of these instances agree on the lock acquisition.
 To release the lock, the client application uses a Lua script, which involves the [`GET`](../command-reference/strings/get.md) command
 and the [`DEL`](../command-reference/generic/del.md) command, to perform compare-and-delete operations on all the instances involved.

--- a/docs/integrations/redlock.md
+++ b/docs/integrations/redlock.md
@@ -1,0 +1,38 @@
+---
+sidebar_position: 1
+description: Redlock
+---
+
+# Redlock
+
+## Introduction
+
+[Redlock](https://redis.io/docs/manual/patterns/distributed-locks/) is a recognized algorithm used with Redis for creating
+distributed locks, ensuring consistent operation and protection against failures such as network partitions and Redis crashes.
+It operates by having a client send lock requests, using the [`SET`](../command-reference/strings/set.md) command, to multiple primary Redis instances.
+The lock is successfully acquired when more than half of these instances agree on the lock acquisition.
+To unlock, the client issues [`DEL`](../command-reference/generic/del.md) commands to all the instances involved.
+
+Since Dragonfly is highly compatible with Redis and both `SET` and `DEL` commands are fully supported, Redlock implementations can be easily used with Dragonfly.
+
+## Implementations
+
+The following is a list of Redlock implementations in various languages, ordered by the language used:
+
+- [redis-plus-plus](https://github.com/sewenew/redis-plus-plus/?tab=readme-ov-file#redlock) (C++)
+- [RedLock.net](https://github.com/samcook/RedLock.net) (C#/.NET)
+- [redsync](https://github.com/go-redsync/redsync) (Go)
+- [redisson](https://github.com/redisson/redisson) (Java)
+- [node-redlock](https://github.com/mike-marcacci/node-redlock) (JavaScript/TypeScript/Node.js)
+- [Deno-Redlock](https://github.com/oslabs-beta/Deno-Redlock) (JavaScript/TypeScript/Deno)
+- [pedlock-php](https://github.com/ronnylt/redlock-php) (PHP)
+- [PHPRedisMutex](https://github.com/php-lock/lock?tab=readme-ov-file#phpredismutex) (PHP)
+- [redlock-py](https://github.com/SPSCommerce/redlock-py) (Python)
+- [pottery](https://github.com/brainix/pottery?tab=readme-ov-file#redlock) (Python)
+- [aioredlock](https://github.com/joanvila/aioredlock) (Python with asyncio)
+- [redlock-rb](https://github.com/antirez/redlock-rb) (Ruby)
+- [rslock](https://github.com/hexcowboy/rslock) (Rust)
+
+## Using Redlock with Dragonfly (Go)
+
+Let's look at how to use Redlock with Dragonfly in a Go application using the `redsync` library.

--- a/docs/integrations/redlock.md
+++ b/docs/integrations/redlock.md
@@ -7,11 +7,12 @@ description: Redlock
 
 ## Introduction
 
-[Redlock](https://redis.io/docs/manual/patterns/distributed-locks/) is a recognized algorithm used with Redis for creating
+[Redlock](https://redis.io/docs/manual/patterns/distributed-locks/) is a recognized algorithm based on Redis for
 distributed locks, ensuring consistent operation and protection against failures such as network partitions and Redis crashes.
-It operates by having a client send lock requests, using the [`SET`](../command-reference/strings/set.md) command, to multiple primary Redis instances.
+It operates by having a client application send lock requests, using [`SET`](../command-reference/strings/set.md) commands, to multiple **primary Redis instances**.
 The lock is successfully acquired when more than half of these instances agree on the lock acquisition.
-To unlock, the client issues [`DEL`](../command-reference/generic/del.md) commands to all the instances involved.
+To release the lock, the client issues [`DEL`](../command-reference/generic/del.md) commands to all the instances involved.
+Redlock also takes into account the lock validity time, retry on failure, lock extension, and many other aspects, which makes it a robust and reliable solution for distributed locking.
 
 Since Dragonfly is highly compatible with Redis and both `SET` and `DEL` commands are fully supported, Redlock implementations can be easily used with Dragonfly.
 

--- a/docs/integrations/redlock.md
+++ b/docs/integrations/redlock.md
@@ -37,3 +37,113 @@ The following is a list of Redlock implementations in various languages, ordered
 ## Using Redlock with Dragonfly (Go)
 
 Let's look at how to use Redlock with Dragonfly in a Go application using the `redsync` library.
+Imagine that you have three Dragonfly instances, which are independent primary instances capable of handling lock requests.
+This setup can be described using a `docker-compose.yml` file as follows:
+
+```yaml
+version: '3'
+services:
+  dragonfly-instance-0:
+    container_name: "dragonfly-instance-0"
+    image: 'ghcr.io/dragonflydb/dragonfly:v1.14.3-ubuntu'
+    ulimits:
+      memlock: -1
+    ports:
+      - "6379:6379"
+  dragonfly-instance-1:
+    container_name: "dragonfly-instance-1"
+    image: 'ghcr.io/dragonflydb/dragonfly:v1.14.3-ubuntu'
+    ulimits:
+      memlock: -1
+    ports:
+      - "6380:6379"
+  dragonfly-instance-2:
+    container_name: "dragonfly-instance-2"
+    image: 'ghcr.io/dragonflydb/dragonfly:v1.14.3-ubuntu'
+    ulimits:
+      memlock: -1
+    ports:
+      - "6381:6379"
+```
+
+Then, you can use the [`redsync`](https://github.com/go-redsync/redsync) library to acquire and release locks in a Go application:
+
+```go
+package main
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/go-redsync/redsync/v4"
+	redsyncredis "github.com/go-redsync/redsync/v4/redis"
+	redsyncpool "github.com/go-redsync/redsync/v4/redis/goredis/v9"
+	"github.com/redis/go-redis/v9"
+)
+
+// These hosts are reachable from within the Docker network.
+const (
+	dragonflyHost0 = "dragonfly-instance-0:6379"
+	dragonflyHost1 = "dragonfly-instance-1:6379"
+	dragonflyHost2 = "dragonfly-instance-2:6379"
+)
+
+const (
+	// The name of the global lock.
+	globalLockKeyName = "my-global-lock"
+
+	// The expiry of the global lock.
+	globalLockExpiry = time.Minute
+
+	// Number of retries to acquire the global lock.
+	globalLockRetries = 8
+
+	// The delay between retries to acquire the global lock.
+	globalLockRetryDelay = 10 * time.Millisecond
+)
+
+func main() {
+	// Create three clients for each instance of Dragonfly.
+	var (
+		hosts   = []string{dragonflyHost0, dragonflyHost1, dragonflyHost2}
+		clients = make([]redsyncredis.Pool, len(hosts))
+	)
+	for idx, addr := range hosts {
+		client := redis.NewClient(&redis.Options{
+			Addr: addr,
+		})
+		clients[idx] = redsyncpool.NewPool(client)
+	}
+
+	// Create an instance of 'Redsync' to work with locks.
+	rs := redsync.New(clients...)
+
+	// Create a global lock mutex.
+	globalMutex := rs.NewMutex(
+		globalLockKeyName,
+		redsync.WithExpiry(globalLockExpiry),
+		redsync.WithTries(globalLockRetries),
+		redsync.WithRetryDelay(globalLockRetryDelay),
+	)
+
+	// Obtain a lock for the global lock mutex.
+	// After this is successful, no one else can obtain the same lock (with the same mutex name),
+	// until we unlock it, or it expires automatically after the specified expiry time.
+	if err := globalMutex.Lock(); err != nil {
+		panic(err)
+	}
+
+	// Do your work that requires the lock.
+	// ...
+
+	// Release the lock so other processes or threads can obtain a lock.
+	if ok, err := globalMutex.Unlock(); !ok || err != nil {
+		panic("unlock failed")
+	}
+}
+```
+
+## Useful Resources
+
+- Redlock [Documentation](https://redis.io/docs/manual/patterns/distributed-locks/).
+- The [dragonfly-examples](https://github.com/dragonflydb/dragonfly-examples) repository, which contains code examples for using Redlock with Dragonfly in Go.

--- a/docs/integrations/relay.md
+++ b/docs/integrations/relay.md
@@ -43,7 +43,7 @@ For different platforms, you can install Relay by following the instructions in 
 Once you have Dragonfly and Relay set up, you can start using Relay with Dragonfly in code.
 For more information on how to use Relay in terms of configuration, integrations, events, and APIs, please refer to the Relay [documentation](https://relay.so/docs).
 
-<!-- PHP is not supported for syntax highlighting yet. -->
+<!-- PHP is not supported for syntax highlighting yet, and the JavaScript highlighting looks fine for this example. -->
 ```javascript
 // Assume Dragonfly is running locally on the default port.
 $relay = new Relay(host: '127.0.0.1', port: 6379);

--- a/docs/integrations/relay.md
+++ b/docs/integrations/relay.md
@@ -5,7 +5,10 @@ description: Relay
 
 # Relay
 
-**Note:** Dragonfly v1.14+ is required for this integration.
+**Notes:**
+
+- Dragonfly v1.14+ and the [RESP3](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md) protocol are required for this integration.
+- See more details about the [`CLIENT TRACKING`](../command-reference/server-management/client-tracking.md) command that enables this integration.
 
 ## Introduction
 

--- a/docs/integrations/relay.md
+++ b/docs/integrations/relay.md
@@ -5,6 +5,8 @@ description: Relay
 
 # Relay
 
+**Note:** Dragonfly v1.14+ is required for this integration.
+
 ## Introduction
 
 [Relay](https://relay.so/) is a revolutionary PHP extension that combines the functionalities of a Redis client

--- a/docs/integrations/relay.md
+++ b/docs/integrations/relay.md
@@ -1,0 +1,61 @@
+---
+sidebar_position: 1
+description: Relay
+---
+
+# Relay
+
+## Introduction
+
+[Relay](https://relay.so/) is a revolutionary PHP extension that combines the functionalities of a Redis client
+with an advanced shared in-memory cache, offering exceptional caching performance enhancements.
+
+Relay can be used as a drop-in replacement for [phpredis](https://github.com/phpredis/phpredis).
+By maintaining a highly-efficient partial replica of Redis data in the PHP master process memory and utilizing real-time cache invalidation and updates, Relay significantly outperforms traditional clients.
+Tailored for shared environments, it allows for precise memory management, employing LRU and LFU eviction policies to optimize performance.
+Relay supports seamless integration across major platforms like Laravel, WordPress, Magento, and Drupal without requiring code modifications.
+
+Dragonfly is highly compatible with Redis, and Relay can be effortlessly used with Dragonfly (v1.14+) with
+[even better performance and efficiency](https://www.dragonflydb.io/blog/relay-with-dragonfly-towards-the-next-gen-caching-infrastructure).
+
+## Using Relay with Dragonfly
+
+### 1. Dragonfly Initialization
+
+There are several options available to [get Dragonfly up and running quickly](../getting-started/getting-started.md).
+Assuming you have a local Dragonfly binary, you can run Dragonfly with the following command:
+
+```bash
+$> ./dragonfly --bind localhost --port 6379
+```
+
+### 2. Relay Installation
+
+For different platforms, you can install Relay by following the instructions in their [documentation](https://relay.so/docs/installation).
+
+### 3. Start Using Relay with Dragonfly
+
+Once you have Dragonfly and Relay set up, you can start using Relay with Dragonfly in code.
+For more information on how to use Relay in terms of configuration, integrations, events, and APIs, please refer to the Relay [documentation](https://relay.so/docs).
+
+<!-- PHP is not supported for syntax highlighting yet. -->
+```javascript
+// Assume Dragonfly is running locally on the default port.
+$relay = new Relay(host: '127.0.0.1', port: 6379);
+
+// Fetch the user count from Relay's memory, or from Dragonfly if the key has not been cached, yet.
+$users = $relay->get('users:count');
+
+// Listen to all invalidation events.
+$relay->onInvalidated(function (Relay\Event $event) use ($users) {
+    if ($event->key === 'users:count') {
+        $users = null;
+    }
+});
+```
+
+## Useful Resources & Benchmarks
+
+- Relay [Homepage](https://relay.so/), [GitHub](https://github.com/cachewerk/relay), and [Documentation](https://relay.so/docs).
+- Read our blog post [Relay with Dragonfly: Towards the Next-Gen Caching Infrastructure](https://www.dragonflydb.io/blog/relay-with-dragonfly-towards-the-next-gen-caching-infrastructure)
+  with internal implementation details and performance benchmarks.

--- a/docs/integrations/sidekiq.md
+++ b/docs/integrations/sidekiq.md
@@ -1,5 +1,5 @@
 ---
-sidebar_position: 4
+sidebar_position: 1
 description: Sidekiq
 ---
 

--- a/docs/integrations/sidekiq.md
+++ b/docs/integrations/sidekiq.md
@@ -43,7 +43,9 @@ With this configuration, Dragonfly equally spreads the Sidekiq queues (lists) am
 Replace `QUEUE_PREFIX` with the prefix name of the Sidekiq queues.
 For example, if your queues are named `my_queue:1`, `my_queue:2`, `my_queue:3`, etc., then replace `QUEUE_PREFIX` with `my_queue`.
 
-## Useful Resources
+## Useful Resources & Benchmarks
 
 - Sidekiq [Homepage](https://sidekiq.org/), [GitHub](https://github.com/sidekiq/sidekiq), and [Documentation](https://github.com/sidekiq/sidekiq/wiki).
 - Sidekiq also has a dedicated documentation page on [Using Dragonfly](https://github.com/sidekiq/sidekiq/wiki/Using-Dragonfly).
+- Read our blog post [Running and Optimizing Sidekiq Workloads with Dragonfly](https://www.dragonflydb.io/blog/running-sidekiq-with-dragonfly)
+  with internal implementation details and performance benchmarks.

--- a/docs/managing-dragonfly/flags.md
+++ b/docs/managing-dragonfly/flags.md
@@ -1,4 +1,4 @@
-# Command line arguments (flags)
+# Server Configuration Flags
 
 Dragonfly can be tuned and configured by a set of config flags. These flags can be:
 


### PR DESCRIPTION
- Add Relay as an integration.
- Add Redlock as an integration.
- Add the `CLIENT TRACKING` command.

---

Note that the Relay blog link is not available until [this PR](https://github.com/dragonflydb/website2/pull/299) is merged.