### PR TITLE
chore: some improvements for ACL, AOF, and replication

### DIFF
--- a/docs/managing-dragonfly/acl.md
+++ b/docs/managing-dragonfly/acl.md
@@ -3,7 +3,7 @@
 Dragonfly has built-in support for ACL. Dragonfly operators get fine-grained control over how and who accesses the datastore via the ACL family of commands.
 Since Dragonfly is designed as a drop-in replacement for Redis, you can expect the same API functionality for ACL as in Redis.
 
-All connections in Dragofnly default to the user `default` (unless that user is disabled). By default, user `default` can `AUTH` in Dragonfly using any password, 
+All connections in Dragonfly default to the user `default` (unless that user is disabled). By default, user `default` can `AUTH` in Dragonfly using any password, 
 and is allowed to execute any command and is part of all the available ACL groups.
 
 Permissions for a given user are controlled via a domain-specific language (DSL) and are divided into 4 categories:

--- a/docs/managing-dragonfly/aof.md
+++ b/docs/managing-dragonfly/aof.md
@@ -1,0 +1,15 @@
+---
+sidebar_position: 3
+---
+
+# Append Only File (AOF)
+
+Append Only File (AOF) captures every write operation received by the server.
+Upon server restart, these operations can be replayed to reconstruct the original dataset.
+The commands are logged in the same format that adheres to the Redis protocol.
+
+**Currently, Dragonfly does not support AOF.**
+The primary reason is the lack of high-priority demand within the community.
+Implementing AOF in Dragonfly would require a different approach than in Redis and is more sophisticated, especially in terms of maintaining high performance.
+However, we are exploring the possibility of including this feature in future releases.
+If you have any thoughts or suggestions about this, we encourage you to join the conversation on our [Discord server](https://discord.com/invite/HsPjXGVH85).

--- a/docs/managing-dragonfly/append-only.md
+++ b/docs/managing-dragonfly/append-only.md
@@ -1,7 +1,0 @@
----
-sidebar_position: 5
----
-
-# Append Only Mode (AOF)
-
-At this time, Dragonfly does not support Append Only Mode (AOF). The primary reason is that it has not been a high priority request in the community. The AOF mode in Dragonfly will require a different approach than in Redis and is more complicated to implement, however, it is something we are considering for future versions. Please join the discussion on the [Dragonfly Discord](https://discord.com/invite/HsPjXGVH85) if you have any thoughts or suggestions on this topic.

--- a/docs/managing-dragonfly/monitoring.md
+++ b/docs/managing-dragonfly/monitoring.md
@@ -4,6 +4,6 @@ sidebar_position: 5
 
 # Monitoring
 
-By default, Dragonfly allows HTTP access via its main TCP port (6379) and it exposes Prometheus compatible metrics on `:6379/metrics`.
+By default, Dragonfly allows HTTP access via its main TCP port (i.e, `6379`) and it exposes Prometheus compatible metrics on `:6379/metrics`.
 
-Checkout this complete example of setting up a [Grafana Monitoring Stack with Dragonfly](https://github.com/dragonflydb/dragonfly/tree/main/tools/local/monitoring).
+Check out this complete example of setting up a [Grafana Monitoring Stack with Dragonfly](https://github.com/dragonflydb/dragonfly/tree/main/tools/local/monitoring).

--- a/docs/managing-dragonfly/monitoring.md
+++ b/docs/managing-dragonfly/monitoring.md
@@ -4,6 +4,6 @@ sidebar_position: 5
 
 # Monitoring
 
-By default, Dragonfly allows HTTP access via its main TCP port (6379) and it exposes prometheus compatible metrics on `:6379/metrics`.
+By default, Dragonfly allows HTTP access via its main TCP port (6379) and it exposes Prometheus compatible metrics on `:6379/metrics`.
 
 Checkout this complete example of setting up a [Grafana Monitoring Stack with Dragonfly](https://github.com/dragonflydb/dragonfly/tree/main/tools/local/monitoring).

--- a/docs/managing-dragonfly/operator/grafana-guide.md
+++ b/docs/managing-dragonfly/operator/grafana-guide.md
@@ -61,8 +61,8 @@ statefulset.apps/prometheus-prometheus   1/1     167m
 
 ## Create Prometheus Service
 
-Create a prometheus Service to let Grafana access prometheus through it. If you already
-have a Prometheus Service object, move to the next step.
+Create a Prometheus Service to let Grafana access prometheus through it.
+If you already have a Prometheus Service object, move to the next step.
 
 ```
 kubectl apply -f https://github.com/dragonflydb/dragonfly-operator/blob/main/monitoring/prometheus-service.yaml

--- a/docs/managing-dragonfly/replication.md
+++ b/docs/managing-dragonfly/replication.md
@@ -4,126 +4,176 @@ sidebar_position: 4
 
 # Replication
 
-## Managing Replicas
+## Managing Replication
 
-Dragonfly supports a primary/secondary replication model, similarly to Redis’s [replication](https://redis.io/topics/replication). When using replication, Dragonfly creates exact copies of the primary instance. Once configured properly, secondary instances reconnect to the primary any time their connections break and will always aim to remain an exact copy of the primary.
+Dragonfly supports a primary-replica high-availability model, similarly to Redis's [replication](https://redis.io/topics/replication).
+When using replication, Dragonfly creates exact copies of the primary instance.
+Once configured properly, replicas reconnect to the primary instance any time their connections break and will always aim to remain an exact copy of the primary.
 
-Dragonfly replication management API is compatible with Redis API and consists of two user-facing commands: ROLE and REPLICAOF (SLAVEOF).
-
-If you’re not sure whether the Dragonfly instance you’re currently connected to is a primary instance or a replica, you can check by running the  `role ` command:
+The Dragonfly replication management API is compatible with the Redis API and consists of two main commands:
+[`ROLE`](../command-reference/server-management/role.md) and [`REPLICAOF`](../command-reference/server-management/replicaof.md).
+If you're not sure whether the Dragonfly instance you're currently connected to is a primary instance or a replica, you can check by running the `ROLE` command:
 
 ```bash
-role
+dragonfly$> ROLE
+1) "master"
+2) 1) 1) "172.19.0.4"
+      2) "6379"
+      3) "stable_sync"
 ```
 
-This command will return either  `master ` or  `replica `.
+This command will return either `master` or `replica` with additional information, depending on the role of the instance.
 
-## Redis/Dragonfly replication
-Dragonfly supports Redis -> Dragonfly replication to allow a convenient migration of Redis workloads to Dragonfly. We currently support data structures and replication protocol of Redis OSS up to version 6.2. The instructions below apply to this type of replication as well with only difference that the primary instance is a running Redis server.
+## Redis-Dragonfly Replication
 
-## Dragonfly/Dragonfly replication
+Dragonfly supports Redis-Dragonfly replication to allow a convenient migration of Redis workloads to Dragonfly.
+We currently support the data structures and replication protocol of Redis OSS up to version 6.2.
+The instructions below apply to this type of replication as well, with the only difference being that the primary instance is a running Redis server.
+
+## Dragonfly-Dragonfly Replication
+
 This replication process internally is vastly different from the original Redis replication algorithm, but from the outside, the API is kept the same to make it compatible with the current ecosystem.
 
-To designate a Dragonfly instance as a replica of another instance on the fly, run the  `replicaof ` command. This command takes the intended primary server’s hostname or IP address and port as arguments:
+To designate a Dragonfly instance as a replica of another instance on the fly, run the `REPLICAOF` command.
+This command takes the intended primary instance's hostname or IP address and port as arguments:
 
 ```bash
-replicaof hostname_or_IP port
+dragonfly$> REPLICAOF hostname_or_IP port
 ```
 
-If the server is already a replica of another primary, it will stop replicating the old server and immediately start synchronizing with the new one. It will also discard the old dataset.
+If the server is already a replica of another primary, it will stop replicating the old primary and immediately start synchronizing with the new one.
+It will also discard the entire old dataset.
 
-To promote a replica back to being a primary, run the following `replicaof` command:
+To promote a replica back to being a primary, run the following `REPLICAOF` command:
+
 ```bash
-replicaof no one
+dragonfly$> REPLICAOF NO ONE
 ```
 
-This will stop the instance from replicating the primary server but will not discard the dataset it has already replicated. This syntax is useful in cases where the original primary fails. After running `replicaof no one` on a replica of the failed primary, the former replica can be used as the new primary and have its own replicas as a failsafe.
+This will stop the instance from replicating the primary instance but will not discard the dataset it has already replicated.
+This syntax is useful in cases where the original primary fails.
+After running `REPLICAOF NO ONE` on a replica of the failed primary, the former replica can be used as the new primary and have its own replicas as a failsafe.
 
-## Secure replication with TLS -- Prerequisites
+## Secure Replication with TLS
 
-Dragonfly supports replication over TLS. To make it work you need:
+### Secure Replication Prerequisites
+
+Dragonfly supports replication over TLS. To make it work, you need:
 
 1. To configure your Dragonfly instance to use TLS. That includes getting or generating a server certificate.
-2. To choose a method of authentication between the replica and the master. This can be either with a password or with client certificates.
+2. To choose a method of authentication between the replica and the primary instance.
+   This can be either with a password or with client certificates.
 
-Also note that we only support `.pem` files, any other format won't work with dragonfly.
+Also note that we only support `.pem` files.
+Any other format won't work with Dragonfly.
 
-You can use `OpenSSL` to generate the required certificates. For example, the process of generating a server certificate and signing it with a self-managed CA is as follows:
+You can use `OpenSSL` to generate the required certificates.
+For example, the process of generating a server certificate and signing it with a self-managed CA is as follows:
 
 Generate Dragonfly's private key and certificate signing request (CSR):
+
 ```bash
 openssl req -newkey rsa:4096 -nodes -keyout server-key.pem -out server-req.pem
 ```
-This will prompt you to add additional details for the subject which contains information
-related to the certificate. The attributes of the subject are key-value pairs and are the following:
 
-- CN: CommonName
-- OU: OrganizationalUnit
-- O: Organization
-- L: Locality
-- S: StateOrProvinceName
-- C: CountryName
+This will prompt you to add additional details for the subject which contains information related to the certificate.
+The attributes of the subject are key-value pairs as follows:
 
-The `-nodes` part means `no DES`, that is, do not encrypt the private key. For production use cases,
-you should always consider encrypting private keys.
+- `CN`: CommonName
+- `OU`: OrganizationalUnit
+- `O`: Organization
+- `L`: Locality
+- `S`: StateOrProvinceName
+- `C`: CountryName
 
-Finally, you should use the CA's private key to sign dragonfly's CSR and get back the signed certificate
+The `-nodes` argument means `no DES`, that is, do not encrypt the private key.
+**For production use cases, you should always consider encrypting private keys.**
+
+Finally, you should use the CA's private key to sign Dragonfly's CSR and get back the signed certificate:
+
 ```bash
 openssl x509 -req -in server-req.pem -days 365 -CA ca-cert.pem -CAkey ca-key.pem -CAcreateserial -out server-cert.pem
 ```
 
-The `ca-cert.pem` and `ca-key.pem` can be generated like in the first step described above. The same process applies for generating client keys.
+The `ca-cert.pem` and `ca-key.pem` can be generated like in the first step described above.
+The same process applies for generating client keys.
+**When generating private keys, always be mindful about storing and provisioning them securely!**
 
-When generating private keys, always be mindful about storing and provisioning them securely!
+### Secure Replication Setup
 
-## Secure replication with TLS
-
-To enable TLS for dragonfly, you must supply the following arguments:
+To enable TLS for Dragonfly, you should supply the following arguments:
 
 ```bash
 dragonfly --tls --tls_key_file=server-key.pem --tls_cert_file=server-cert.pem --tls_ca_cert_file=ca-cert.pem
 ```
 
-Start the replica on a different port (in this example the port is 6380, and the host is local host):
+Start the secondary Dragonfly instance on a different port (i.e., `6380`) with the following arguments:
+
 ```bash
 dragonfly --tls --tls_key_file=replica-client-key.pem --tls_cert_file=replica-client-cert.pem --tls_ca_cert_file=ca-cert.pem --tls_replication=true --port 6380
 ```
 
-Finally, connect to the replica and issue a `REPLICAOF` command:
+Finally, connect to the secondary Dragonfly instance and issue the `REPLICAOF` command:
 
 ```bash
 redis-cli --tls --key ./client-key.pem --cert ./client-cert.pem --cacert ./ca-cert.pem -p 6380
 
-REPLICAOF LOCALHOST 6379
+dragonfly$> REPLICAOF PRIMARY_HOST 6379
 ```
-Now, replication works over TLS and is secure. This example assumes that `ca-cert.pem` is a root certificate
-used to authenticate both the server and the client. For example, if the server is using a certificate
-signed by a public CA this flag should not be passed as an argument to the replica.
 
-## Non TLS connections over admin port on TLS configured dragonfly
+Now, the replication works over TLS and is secure.
+This example assumes that `ca-cert.pem` is a root certificate used to authenticate both the server and the client.
+For example, if the server is using a certificate signed by a public CA, this flag should not be passed as an argument to the replica.
 
-Sometimes, it might be the case that both the master and the replica are on the same private network. For that case, you might want TLS for connections outside of the private network but have plaintext communication over the more secure private network. In cases like this you can disable tls replication specifically on the admin port:
+## Non-TLS Connections over Admin Ports
 
-Start master with:
+In some scenarios, **both the primary instance and its replica may be located on the same private network.**
+Under these circumstances, you might prefer to use TLS for connections that are external to the private network
+while allowing plaintext communication within the secure confines of the private network.
+For situations like these, it's possible to specifically disable TLS for replication on the admin port, as described below.
+
+Start the primary instance with:
+
 ```bash
-dragonfly --tls --tls_key_file=server-key.pem --tls_cert_file=server-cert.pem --tls_ca_cert_file=ca-cert.pem -admin_port=6380 --no_tls_on_admin_port=true
+dragonfly --tls --tls_key_file=server-key.pem \
+          --tls_cert_file=server-cert.pem \
+          --tls_ca_cert_file=ca-cert.pem \
+          --port 6379 -admin_port=6380 --no_tls_on_admin_port=true
 ```
 
-Start replica with:
+Start the secondary Dragonfly instance with:
+
 ```bash
-dragonfly --tls --tls_key_file=replica-client-key.pem --tls_cert_file=replica-client-cert.pem --tls_ca_cert_file=ca-cert.pem --port 6381 -admin_port=6382
+dragonfly --tls --tls_key_file=replica-client-key.pem \
+          --tls_cert_file=replica-client-cert.pem \
+          --tls_ca_cert_file=ca-cert.pem
+          --port 6381 -admin_port=6382
 ```
 
-And then issue a `REPLICAOF` command through the admin port via:
+Then, connect to the secondary Dragonfly instance and issue the `REPLICAOF` command via the admin port:
 
 ```bash
 redis-cli -p 6382
 
-REPLICAOF HOST 6380
+dragonfly$> REPLICAOF PRIMARY_HOST 6380
 ```
 
-from now on the replica *does not* communicate over TLS but incoming connections on ports `6379, 6381` require TLS and are considered secure.
+From now on, the replica **does not** communicate with the primary instance over TLS.
+But incoming connections on ports `6379` and `6381` still require TLS and are considered secure.
 
-## Monitoring Lag
+## Monitoring Replication Lag
 
-Dragonfly defines the replication lag as the maximal amount of unacknowledged database among all shards. This metric is calculated by the master instance and is visible both as the `dragonfly_connected_replica_lag_records` field in the [prometheus metrics](./monitoring.md), and through the `INFO REPLICATION` command.
+Dragonfly defines the replication lag as the maximal amount of unacknowledged database among all shards.
+This metric is calculated by the primary instance and is visible both as the `dragonfly_connected_replica_lag_records` field in the [prometheus metrics](./monitoring.md)
+as well as in the `INFO REPLICATION` command output as the `lag` field.
+
+```bash
+# On the primary instance:
+
+dragonfly$> INFO REPLICATION
+# Replication
+role:master
+connected_slaves:1
+slave0:ip=127.0.0.1,port=6380,state=stable_sync,lag=0 # <- The replication lag is reported here.
+master_replid:3ad69228e6973c1fc24805efb46d3f6eeeee4fde
+```

--- a/docs/managing-dragonfly/replication.md
+++ b/docs/managing-dragonfly/replication.md
@@ -164,7 +164,7 @@ But incoming connections on ports `6379` and `6381` still require TLS and are co
 ## Monitoring Replication Lag
 
 Dragonfly defines the replication lag as the maximal amount of unacknowledged database among all shards.
-This metric is calculated by the primary instance and is visible both as the `dragonfly_connected_replica_lag_records` field in the [prometheus metrics](./monitoring.md)
+This metric is calculated by the primary instance and is visible both as the `dragonfly_connected_replica_lag_records` field in the [Prometheus metrics](./monitoring.md)
 as well as in the `INFO REPLICATION` command output as the `lag` field.
 
 ```bash

--- a/docs/managing-dragonfly/replication.md
+++ b/docs/managing-dragonfly/replication.md
@@ -146,7 +146,7 @@ Start the secondary Dragonfly instance with:
 ```bash
 dragonfly --tls --tls_key_file=replica-client-key.pem \
           --tls_cert_file=replica-client-cert.pem \
-          --tls_ca_cert_file=ca-cert.pem
+          --tls_ca_cert_file=ca-cert.pem \
           --port 6381 -admin_port=6382
 ```
 

--- a/docs/managing-dragonfly/replication.md
+++ b/docs/managing-dragonfly/replication.md
@@ -92,7 +92,9 @@ The `-nodes` argument means `no DES`, that is, do not encrypt the private key.
 Finally, you should use the CA's private key to sign Dragonfly's CSR and get back the signed certificate:
 
 ```bash
-openssl x509 -req -in server-req.pem -days 365 -CA ca-cert.pem -CAkey ca-key.pem -CAcreateserial -out server-cert.pem
+openssl x509 -req -in server-req.pem -days 365 \
+             -CA ca-cert.pem -CAkey ca-key.pem \
+             -CAcreateserial -out server-cert.pem
 ```
 
 The `ca-cert.pem` and `ca-key.pem` can be generated like in the first step described above.
@@ -104,13 +106,18 @@ The same process applies for generating client keys.
 To enable TLS for Dragonfly, you should supply the following arguments:
 
 ```bash
-dragonfly --tls --tls_key_file=server-key.pem --tls_cert_file=server-cert.pem --tls_ca_cert_file=ca-cert.pem
+dragonfly --tls --tls_key_file=server-key.pem \
+          --tls_cert_file=server-cert.pem \
+          --tls_ca_cert_file=ca-cert.pem
 ```
 
 Start the secondary Dragonfly instance on a different port (i.e., `6380`) with the following arguments:
 
 ```bash
-dragonfly --tls --tls_key_file=replica-client-key.pem --tls_cert_file=replica-client-cert.pem --tls_ca_cert_file=ca-cert.pem --tls_replication=true --port 6380
+dragonfly --tls --tls_key_file=replica-client-key.pem \
+          --tls_cert_file=replica-client-cert.pem \
+          --tls_ca_cert_file=ca-cert.pem \
+          --tls_replication=true --port 6380
 ```
 
 Finally, connect to the secondary Dragonfly instance and issue the `REPLICAOF` command:

--- a/docs/managing-dragonfly/using-http.md
+++ b/docs/managing-dragonfly/using-http.md
@@ -6,6 +6,7 @@ the same port as the main `TCP` port. However, this can be turned off by the com
 supports `HTTP` on admin port.
 
 ## Authentication
+
 By default, HTTP does not require authentication. However, if `requirepass` is set then
 the HTTP request should authorize with username `default` and the password will be the value
 of `requirepass`.
@@ -18,7 +19,7 @@ the `default` ACL user password because the vice versa is not true, that is,
 Also, if `admin_nopass` is set, it bypasses the `requirepass` option on admin port, allowing
 all requests to that port without any authentication.
 
-## Metrics page
+## Metrics Page
 
 Keep in mind that the `/metrics` page always bypasses auth. That means that a user can freely
 view that page without any authentication.


### PR DESCRIPTION
- Fix a typo on the `ACL` page.
- Add more context to the `AOF` page.
- Clean up the `Replication` page a bit.