### PR TITLE
fix: FIELDTTL title & add warning about being dragonfly-specific

### DIFF
--- a/docs/command-reference/generic/fieldttl.md
+++ b/docs/command-reference/generic/fieldttl.md
@@ -6,7 +6,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 # FIELDTTL
 
-<PageTitle title="Redis TTL Command (Documentation) | Dragonfly" />
+<PageTitle title="Redis FIELDTTL Command (Documentation) | Dragonfly" />
 
 ## Syntax
 
@@ -15,6 +15,8 @@ import PageTitle from '@site/src/components/PageTitle';
 **Time complexity:** O(1)
 
 **ACL categories:** @keyspace, @read, @fast
+
+**Warning:** Experimental! Dragonfly-specific.
 
 Returns the remaining time to live of a field that has a timeout (either hash or set).
 This introspection capability allows a Dragonfly client to check how many seconds a given field will continue to be part of the dataset.


### PR DESCRIPTION
Title is wrong and added the disclaimer that exists in `HSETEX`.

I'm also confused about the addition of `FIELDTTL` in `SETEX` - `SETEX` has nothing to do with sets!
In fact, I can't find any commands related to the set expiration mentioned in https://github.com/dragonflydb/dragonfly/pull/3039#issuecomment-2105999667