### PR TITLE
chore: update compatibility table

### DIFF
--- a/docs/command-reference/compatibility.md
+++ b/docs/command-reference/compatibility.md
@@ -5,7 +5,7 @@ sidebar_position: 0
 # Dragonfly API Compatibility
 
 | Command Family                               | Command                                                    | Dragonfly Support                                        |
-| :------------------------------------------- | :--------------------------------------------------------- | :------------------------------------------------------- |
+|:---------------------------------------------|:-----------------------------------------------------------|:---------------------------------------------------------|
 | <span class="family">Bitmap</span>           | <span class="command">BITCOUNT</span>                      | <span class="support supported">Fully supported</span>   |
 |                                              | <span class="command">BITFIELD</span>                      | <span class="support supported">Fully supported</span>   |
 |                                              | <span class="command">BITFIELD_RO</span>                   | <span class="support supported">Fully supported</span>   |


### PR DESCRIPTION
- `CLIENT CACHING` should be fully supported after v1.20
- Reformat the API compatibility markdown table.