### PR TITLE
fix(operator): Use proper format for affinity example

### DIFF
--- a/docs/managing-dragonfly/operator/dragonfly-configuration.md
+++ b/docs/managing-dragonfly/operator/dragonfly-configuration.md
@@ -12,7 +12,7 @@ controller and the dragonfly pods. Below is the table of Dragonfly CRD fields.
 
 | fields | type | Description |
 | ------ | ---- | ----------- |
-| `affinity` | [Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#affinity-v1-core) | Dragonfly pod affinity (Optional)<br/><pre>spec:<br/>  affinity: <br/>    nodeaffinity:<br/>      ...</pre> You can learn more about affinity [here](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity).|
+| `affinity` | [Affinity](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.28/#affinity-v1-core) | Dragonfly pod affinity (Optional)<br/><pre>spec:<br/>  affinity: <br/>    nodeAffinity:<br/>      ...</pre> You can learn more about affinity [here](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity).|
 | `replicas` | int | The total number of Dragonfly instances including the master. |
 | `image` | string | The dragonfly image (i.e. release version) to use. Default is `docker.dragonflydb.io/dragonflydb/dragonfly:v1.21.2` |
 | `args` | []string | (Optional) Dragonfly container args to pass to the container. Refer to the Dragonfly documentation for the list of supported args. Example - <br/><pre>spec:<br/>  args:<br/>   - "--cluster_mode=emulated"</pre> |


### PR DESCRIPTION
The correct setting for the example here is `nodeAffinity`, not `nodeaffinity`. We had an internal user copy this example, which caused a GitOps issue and the setting being ignored.