### PR TITLE
fix: broken links

### DIFF
--- a/docs/command-reference/acl/cat.md
+++ b/docs/command-reference/acl/cat.md
@@ -19,7 +19,7 @@ If a category name is given, the command shows all the Dragonfly commands in the
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays)
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays)
 
 ## Examples
 

--- a/docs/command-reference/acl/deluser.md
+++ b/docs/command-reference/acl/deluser.md
@@ -21,7 +21,7 @@ In such cases, no operation is performed for the non-existent ACL users.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the number of users that were deleted.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the number of users that were deleted.
 This number will not always match the number of arguments since certain users may not exist.
 
 ## Examples

--- a/docs/command-reference/acl/dryrun.md
+++ b/docs/command-reference/acl/dryrun.md
@@ -19,8 +19,8 @@ It can be used to test the permissions without having to enable the user or caus
 
 ## Return
 
-- [Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): `OK` on success.
-- [Bulk string reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings): an error describing why the user can't execute the command.
+- [Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): `OK` on success.
+- [Bulk string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings): an error describing why the user can't execute the command.
 
 ## Examples
 

--- a/docs/command-reference/acl/getuser.md
+++ b/docs/command-reference/acl/getuser.md
@@ -18,8 +18,8 @@ The command returns all the rules defined for an existing ACL user.
 
 ## Return
 
-- [Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): a list of ACL rule definitions for the user.
-- [Null reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings): if the user does not exist.
+- [Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): a list of ACL rule definitions for the user.
+- [Null reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings): if the user does not exist.
 
 ## Examples
 

--- a/docs/command-reference/acl/list.md
+++ b/docs/command-reference/acl/list.md
@@ -19,7 +19,7 @@ Each line consists of the username, followed by their status (ON/OFF), a 15-char
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): An array of strings. 
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): An array of strings. 
 
 ## Examples
 

--- a/docs/command-reference/acl/load.md
+++ b/docs/command-reference/acl/load.md
@@ -18,7 +18,7 @@ When Dragonfly is configured to use an ACL file (with the `--aclfile` configurat
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): `OK` on success.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): `OK` on success.
 The error otherwise.
 
 ## Examples

--- a/docs/command-reference/acl/log.md
+++ b/docs/command-reference/acl/log.md
@@ -27,10 +27,10 @@ The `RESET` arguments clears the log.
 
 When called to show security events:
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): a list of ACL security events.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): a list of ACL security events.
 
 When called with `RESET`:
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): `OK` if the security log was cleared.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): `OK` if the security log was cleared.
 
 ## Examples
 

--- a/docs/command-reference/acl/save.md
+++ b/docs/command-reference/acl/save.md
@@ -22,7 +22,7 @@ you plan them to be read only (and in that case it would make sense to store the
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): `OK` on success.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): `OK` on success.
 The error otherwise.
 
 ## Examples

--- a/docs/command-reference/acl/setuser.md
+++ b/docs/command-reference/acl/setuser.md
@@ -64,7 +64,7 @@ This restriction does not exist on the rest of the family of pub/sub commands.
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): `OK` on success. If the rules contain errors, the error is returned.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): `OK` on success. If the rules contain errors, the error is returned.
 
 ## Examples
 

--- a/docs/command-reference/acl/users.md
+++ b/docs/command-reference/acl/users.md
@@ -18,7 +18,7 @@ Shows a list of all the usernames in Dragonfly.
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays)
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays)
 
 ## Examples
 

--- a/docs/command-reference/acl/whoami.md
+++ b/docs/command-reference/acl/whoami.md
@@ -18,7 +18,7 @@ Return the username the current connection is authenticated with.
 
 ## Return
 
-[Bulk string reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings): the username of the current connection.
+[Bulk string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings): the username of the current connection.
 
 ## Examples
 

--- a/docs/command-reference/bloom-filter/bf.add.md
+++ b/docs/command-reference/bloom-filter/bf.add.md
@@ -20,7 +20,7 @@ If the `key` does not exist, a new Bloom filter is created with default paramete
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers):
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers):
 
 - `1` if the item was successfully added to the filter.
 - `0` if the item was already added to the filter, which could be a false positive.

--- a/docs/command-reference/bloom-filter/bf.exists.md
+++ b/docs/command-reference/bloom-filter/bf.exists.md
@@ -19,7 +19,7 @@ Checks for the existence of a single item in a Bloom filter `key`.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers):
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers):
 
 - `1` if the item exists with a high probability.
 - `0` if the item definitely does not exist.

--- a/docs/command-reference/bloom-filter/bf.madd.md
+++ b/docs/command-reference/bloom-filter/bf.madd.md
@@ -19,7 +19,7 @@ Adds one or more items to a Bloom filter `key`.
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays):
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays):
 an array of integers, each representing the result for an individual item as if being processed by the [`BF.ADD`](./bf.add.md) command:
 
 - `1` if the item was successfully added to the filter.

--- a/docs/command-reference/bloom-filter/bf.mexists.md
+++ b/docs/command-reference/bloom-filter/bf.mexists.md
@@ -19,7 +19,7 @@ Checks for the existence of one or more items in a Bloom filter `key`.
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays):
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays):
 an array of integers, each representing the result for an individual item as if being processed by the [`BF.EXISTS`](./bf.exists.md) command:
 
 - `1` if the item exists with a high probability.

--- a/docs/command-reference/bloom-filter/bf.reserve.md
+++ b/docs/command-reference/bloom-filter/bf.reserve.md
@@ -20,7 +20,7 @@ and a false positive rate `false_positive_rate` that should be a double between 
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): `OK` if the Bloom filter was created successfully.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): `OK` if the Bloom filter was created successfully.
 
 ## Examples
 

--- a/docs/command-reference/generic/del.md
+++ b/docs/command-reference/generic/del.md
@@ -21,7 +21,7 @@ A key is ignored if it does not exist.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): The number of keys that were removed.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): The number of keys that were removed.
 
 ## Examples
 

--- a/docs/command-reference/generic/discard.md
+++ b/docs/command-reference/generic/discard.md
@@ -25,4 +25,4 @@ If `WATCH` was used, `DISCARD` unwatches all keys watched by the connection.
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): always `OK`.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): always `OK`.

--- a/docs/command-reference/generic/dump.md
+++ b/docs/command-reference/generic/dump.md
@@ -38,7 +38,7 @@ If `key` does not exist a nil bulk reply is returned.
 
 ## Return
 
-[Bulk string reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings): the serialized value.
+[Bulk string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings): the serialized value.
 
 ## Examples
 

--- a/docs/command-reference/generic/exec.md
+++ b/docs/command-reference/generic/exec.md
@@ -28,7 +28,7 @@ not modified, allowing for a [check-and-set mechanism][ttc].
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): each element being the reply to each of the commands in the
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): each element being the reply to each of the commands in the
 atomic transaction.
 
-When using `WATCH`, `EXEC` can return a [Null reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings) if the execution was aborted.
+When using `WATCH`, `EXEC` can return a [Null reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings) if the execution was aborted.

--- a/docs/command-reference/generic/exists.md
+++ b/docs/command-reference/generic/exists.md
@@ -22,7 +22,7 @@ The user should be aware that if the same existing key is mentioned in the argum
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers), specifically the number of keys that exist from those specified as arguments.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers), specifically the number of keys that exist from those specified as arguments.
 
 ## Examples
 

--- a/docs/command-reference/generic/expire.md
+++ b/docs/command-reference/generic/expire.md
@@ -59,7 +59,7 @@ _Navigation session_ pattern section below.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers), specifically:
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers), specifically:
 
 - `1` if the timeout was set.
 - `0` if the timeout was not set. e.g. key doesn't exist, or operation skipped due to the provided arguments.

--- a/docs/command-reference/generic/expireat.md
+++ b/docs/command-reference/generic/expireat.md
@@ -28,7 +28,7 @@ Please for the specific semantics of the command refer to the documentation of
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers), specifically:
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers), specifically:
 
 - `1` if the timeout was set.
 - `0` if the timeout was not set. e.g. key doesn't exist, or operation skipped due to the provided arguments.

--- a/docs/command-reference/generic/fieldttl.md
+++ b/docs/command-reference/generic/fieldttl.md
@@ -24,7 +24,7 @@ A ```WRONGTYPE``` error is returned if the key is not a hash or set.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): TTL in seconds, or a negative value in order to signal an error.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): TTL in seconds, or a negative value in order to signal an error.
 
 - The command returns `-1` if the field exists but has no associated TTL.
 - The command returns `-2` if the key does not exist.

--- a/docs/command-reference/generic/keys.md
+++ b/docs/command-reference/generic/keys.md
@@ -33,7 +33,7 @@ Use `\` to escape special characters if you want to match them verbatim.
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): list of keys matching `pattern`.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): list of keys matching `pattern`.
 
 **Number of elements returned:**
 

--- a/docs/command-reference/generic/move.md
+++ b/docs/command-reference/generic/move.md
@@ -24,7 +24,7 @@ It is possible to use `MOVE` as a locking primitive because of this.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers), specifically:
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers), specifically:
 
 - `1` if `key` was moved.
 - `0` if `key` was not moved.

--- a/docs/command-reference/generic/multi.md
+++ b/docs/command-reference/generic/multi.md
@@ -23,4 +23,4 @@ Subsequent commands will be queued for atomic execution using `EXEC`.
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): always `OK`.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): always `OK`.

--- a/docs/command-reference/generic/persist.md
+++ b/docs/command-reference/generic/persist.md
@@ -22,7 +22,7 @@ is associated).
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers), specifically:
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers), specifically:
 
 - `1` if the timeout was removed.
 - `0` if `key` does not exist or does not have an associated timeout.

--- a/docs/command-reference/generic/pexpire.md
+++ b/docs/command-reference/generic/pexpire.md
@@ -21,7 +21,7 @@ specified in milliseconds instead of seconds.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers), specifically:
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers), specifically:
 
 - `1` if the timeout was set.
 - `0` if the timeout was not set. e.g. key doesn't exist, or operation skipped due to the provided arguments.

--- a/docs/command-reference/generic/pexpireat.md
+++ b/docs/command-reference/generic/pexpireat.md
@@ -21,7 +21,7 @@ which the key will expire is specified in milliseconds instead of seconds.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers), specifically:
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers), specifically:
 
 - `1` if the timeout was set.
 - `0` if the timeout was not set. e.g. key doesn't exist, or operation skipped due to the provided arguments.

--- a/docs/command-reference/generic/pttl.md
+++ b/docs/command-reference/generic/pttl.md
@@ -22,7 +22,7 @@ time in seconds while `PTTL` returns it in milliseconds.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): TTL in milliseconds, or a negative value in order to signal an error.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): TTL in milliseconds, or a negative value in order to signal an error.
 
 - The command returns `-2` if the key does not exist.
 - The command returns `-1` if the key exists but has no associated expire.

--- a/docs/command-reference/generic/rename.md
+++ b/docs/command-reference/generic/rename.md
@@ -22,7 +22,7 @@ If `newkey` already exists it is overwritten, when this happens `RENAME` execute
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings)
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings)
 
 ## Examples
 

--- a/docs/command-reference/generic/renamenx.md
+++ b/docs/command-reference/generic/renamenx.md
@@ -21,7 +21,7 @@ It returns an error when `key` does not exist.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers), specifically:
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers), specifically:
 
 - `1` if `key` was renamed to `newkey`.
 - `0` if `newkey` already exists.

--- a/docs/command-reference/generic/restore.md
+++ b/docs/command-reference/generic/restore.md
@@ -34,7 +34,7 @@ exists unless you use the `REPLACE` modifier.
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): The command returns OK on success.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): The command returns OK on success.
 
 ## Examples
 

--- a/docs/command-reference/generic/script-exists.md
+++ b/docs/command-reference/generic/script-exists.md
@@ -30,7 +30,7 @@ For more information about `EVAL` scripts please refer to [Introduction to Eval 
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays) The command returns an array of integers that correspond to
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays) The command returns an array of integers that correspond to
 the specified SHA1 digest arguments.
 For every corresponding SHA1 digest of a script that actually exists in the
 script cache, a 1 is returned, otherwise 0 is returned.

--- a/docs/command-reference/generic/script-help.md
+++ b/docs/command-reference/generic/script-help.md
@@ -20,4 +20,4 @@ The `SCRIPT HELP` command returns a helpful text describing the different subcom
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): a list of subcommands and their descriptions
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): a list of subcommands and their descriptions

--- a/docs/command-reference/generic/script-latency.md
+++ b/docs/command-reference/generic/script-latency.md
@@ -20,4 +20,4 @@ Prints latency histograms in usec for all called scripts.
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays) This command returns an array of elements. The first element is the SHA1 digest of the scripts added into the script cache. The second element is latency historgram.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays) This command returns an array of elements. The first element is the SHA1 digest of the scripts added into the script cache. The second element is latency historgram.

--- a/docs/command-reference/generic/script-list.md
+++ b/docs/command-reference/generic/script-list.md
@@ -20,4 +20,4 @@ Returns information about all the scripts in the script cache.
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays) This command returns an array of elements. The first element is the SHA1 digest of the scripts added into the script cache. The second element is lua script.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays) This command returns an array of elements. The first element is the SHA1 digest of the scripts added into the script cache. The second element is lua script.

--- a/docs/command-reference/generic/script-load.md
+++ b/docs/command-reference/generic/script-load.md
@@ -31,5 +31,5 @@ For more information about `EVAL` scripts please refer to [Introduction to Eval 
 
 ## Return
 
-[Bulk string reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings) This command returns the SHA1 digest of the script added into the
+[Bulk string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings) This command returns the SHA1 digest of the script added into the
 script cache.

--- a/docs/command-reference/generic/sort.md
+++ b/docs/command-reference/generic/sort.md
@@ -69,4 +69,4 @@ SORT mylist LIMIT 0 5 ALPHA DESC
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): list of sorted elements.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): list of sorted elements.

--- a/docs/command-reference/generic/stick.md
+++ b/docs/command-reference/generic/stick.md
@@ -21,7 +21,7 @@ This command is Dragonfly-specific.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): Number of keys that were made sticky successfully: those that existed and were not already sticky.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): Number of keys that were made sticky successfully: those that existed and were not already sticky.
 
 ## Examples
 

--- a/docs/command-reference/generic/touch.md
+++ b/docs/command-reference/generic/touch.md
@@ -21,7 +21,7 @@ A key is ignored if it does not exist.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): The number of keys that were touched.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): The number of keys that were touched.
 
 ## Examples
 

--- a/docs/command-reference/generic/ttl.md
+++ b/docs/command-reference/generic/ttl.md
@@ -22,7 +22,7 @@ given key will continue to be part of the dataset.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): TTL in seconds, or a negative value in order to signal an error.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): TTL in seconds, or a negative value in order to signal an error.
 
 - The command returns `-2` if the key does not exist.
 - The command returns `-1` if the key exists but has no associated expire.

--- a/docs/command-reference/generic/type.md
+++ b/docs/command-reference/generic/type.md
@@ -22,7 +22,7 @@ The different types that can be returned are: `string`, `list`, `set`, `zset`,
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): type of `key`, or `none` when `key` does not exist.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): type of `key`, or `none` when `key` does not exist.
 
 ## Examples
 

--- a/docs/command-reference/generic/unlink.md
+++ b/docs/command-reference/generic/unlink.md
@@ -20,7 +20,7 @@ This command is equivalent to `DEL` command, see `DEL` for more information.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): The number of keys that were unlinked.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): The number of keys that were unlinked.
 
 ## Examples
 

--- a/docs/command-reference/generic/unwatch.md
+++ b/docs/command-reference/generic/unwatch.md
@@ -24,4 +24,4 @@ If you call `EXEC` or `DISCARD`, there's no need to manually call `UNWATCH`.
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): always `OK`.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): always `OK`.

--- a/docs/command-reference/generic/watch.md
+++ b/docs/command-reference/generic/watch.md
@@ -23,4 +23,4 @@ Marks the given keys to be watched for conditional execution of a
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): always `OK`.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): always `OK`.

--- a/docs/command-reference/geospatial-indices/geoadd.md
+++ b/docs/command-reference/geospatial-indices/geoadd.md
@@ -37,7 +37,7 @@ Note: The `XX` and `NX` options are mutually exclusive.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers), specifically:
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers), specifically:
 
 - When used without optional arguments, the number of elements added to the sorted set (excluding score updates).
 - If the `CH` option is specified, the number of elements that were changed (added or updated).

--- a/docs/command-reference/geospatial-indices/geodist.md
+++ b/docs/command-reference/geospatial-indices/geodist.md
@@ -33,7 +33,7 @@ The distance is computed assuming that the Earth is a perfect sphere, so errors 
 
 ## Return
 
-[Bulk string reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings), specifically:
+[Bulk string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings), specifically:
 
 The command returns the distance as a double (represented as a string) in the specified unit, or NULL if one or both the elements are missing.
 

--- a/docs/command-reference/geospatial-indices/geohash.md
+++ b/docs/command-reference/geospatial-indices/geohash.md
@@ -30,7 +30,7 @@ The returned Geohashes have the following properties:
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays), specifically:
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays), specifically:
 
 The command returns an array where each element is the Geohash corresponding to each member name passed as argument to the command.
 

--- a/docs/command-reference/geospatial-indices/geopos.md
+++ b/docs/command-reference/geospatial-indices/geopos.md
@@ -26,7 +26,7 @@ The command can accept a variable number of arguments, so it always returns an a
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays), specifically:
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays), specifically:
 
 The command returns an array where each element is a two elements array representing longitude and latitude (x,y) of each member name passed as argument to the command.
 

--- a/docs/command-reference/geospatial-indices/geosearch.md
+++ b/docs/command-reference/geospatial-indices/geosearch.md
@@ -52,7 +52,7 @@ so to query very large areas with a very small `COUNT` option may be slow even i
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays), specifically:
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays), specifically:
 
 * Without any `WITH` option specified, the command just returns a linear array like ["New York","Milan","Paris"].
 * If `WITHCOORD`, `WITHDIST` or `WITHHASH` options are specified, the command returns an array of arrays, where each sub-array represents a single item.

--- a/docs/command-reference/hashes/hdel.md
+++ b/docs/command-reference/hashes/hdel.md
@@ -23,7 +23,7 @@ If `key` does not exist, it is treated as an empty hash and this command returns
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the number of fields that were removed from the hash, not
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the number of fields that were removed from the hash, not
 including specified but non existing fields.
 
 ## Examples

--- a/docs/command-reference/hashes/hexists.md
+++ b/docs/command-reference/hashes/hexists.md
@@ -20,7 +20,7 @@ Returns if `field` is an existing field in the hash stored at `key`.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers), specifically:
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers), specifically:
 
 - `1` if the hash contains `field`.
 - `0` if the hash does not contain `field`, or `key` does not exist.

--- a/docs/command-reference/hashes/hget.md
+++ b/docs/command-reference/hashes/hget.md
@@ -20,7 +20,7 @@ Returns the value associated with `field` in the hash stored at `key`.
 
 ## Return
 
-[Bulk string reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings): the value associated with `field`, or `nil` when `field` is not
+[Bulk string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings): the value associated with `field`, or `nil` when `field` is not
 present in the hash or `key` does not exist.
 
 ## Examples

--- a/docs/command-reference/hashes/hgetall.md
+++ b/docs/command-reference/hashes/hgetall.md
@@ -22,7 +22,7 @@ of the reply is twice the size of the hash.
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): list of fields and their values stored in the hash, or an
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): list of fields and their values stored in the hash, or an
 empty list when `key` does not exist.
 
 ## Examples

--- a/docs/command-reference/hashes/hincrby.md
+++ b/docs/command-reference/hashes/hincrby.md
@@ -26,7 +26,7 @@ The range of values supported by `HINCRBY` is limited to 64 bit signed integers.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the value at `field` after the increment operation.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the value at `field` after the increment operation.
 
 ## Examples
 

--- a/docs/command-reference/hashes/hincrbyfloat.md
+++ b/docs/command-reference/hashes/hincrbyfloat.md
@@ -32,7 +32,7 @@ information.
 
 ## Return
 
-[Bulk string reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings): the value of `field` after the increment.
+[Bulk string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings): the value of `field` after the increment.
 
 ## Examples
 

--- a/docs/command-reference/hashes/hkeys.md
+++ b/docs/command-reference/hashes/hkeys.md
@@ -20,7 +20,7 @@ Returns all field names in the hash stored at `key`.
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): list of fields in the hash, or an empty list when `key` does
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): list of fields in the hash, or an empty list when `key` does
 not exist.
 
 ## Examples

--- a/docs/command-reference/hashes/hlen.md
+++ b/docs/command-reference/hashes/hlen.md
@@ -20,7 +20,7 @@ Returns the number of fields contained in the hash stored at `key`.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): number of fields in the hash, or `0` when `key` does not exist.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): number of fields in the hash, or `0` when `key` does not exist.
 
 ## Examples
 

--- a/docs/command-reference/hashes/hmget.md
+++ b/docs/command-reference/hashes/hmget.md
@@ -25,7 +25,7 @@ a non-existing `key` will return a list of `nil` values.
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): list of values associated with the given fields, in the same
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): list of values associated with the given fields, in the same
 order as they are requested.
 
 ```shell

--- a/docs/command-reference/hashes/hmset.md
+++ b/docs/command-reference/hashes/hmset.md
@@ -23,7 +23,7 @@ If `key` does not exist, a new key holding a hash is created.
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings)
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings)
 
 ## Examples
 

--- a/docs/command-reference/hashes/hrandfield.md
+++ b/docs/command-reference/hashes/hrandfield.md
@@ -28,9 +28,9 @@ The optional `WITHVALUES` modifier changes the reply so it includes the respecti
 
 ## Return
 
-[Bulk string reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings): without the additional `count` argument, the command returns a Bulk Reply with the randomly selected field, or `nil` when `key` does not exist.
+[Bulk string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings): without the additional `count` argument, the command returns a Bulk Reply with the randomly selected field, or `nil` when `key` does not exist.
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): when the additional `count` argument is passed, the command returns an array of fields, or an empty array when `key` does not exist.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): when the additional `count` argument is passed, the command returns an array of fields, or an empty array when `key` does not exist.
 If the `WITHVALUES` modifier is used, the reply is a list fields and their values from the hash.
 
 ## Examples

--- a/docs/command-reference/hashes/hset.md
+++ b/docs/command-reference/hashes/hset.md
@@ -23,7 +23,7 @@ If `key` doesn't exist, a new key holding a hash is created.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): The number of fields that were added.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): The number of fields that were added.
 
 ## Examples
 

--- a/docs/command-reference/hashes/hsetex.md
+++ b/docs/command-reference/hashes/hsetex.md
@@ -28,7 +28,7 @@ The expiration time can be accessed with the [`FIELDTTL`](../generic/fieldttl.md
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): The number of fields that were added.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): The number of fields that were added.
 
 ## Examples
 

--- a/docs/command-reference/hashes/hsetnx.md
+++ b/docs/command-reference/hashes/hsetnx.md
@@ -23,7 +23,7 @@ If `field` already exists, this operation has no effect.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers), specifically:
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers), specifically:
 
 - `1` if `field` is a new field in the hash and `value` was set.
 - `0` if `field` already exists in the hash and no operation was performed.

--- a/docs/command-reference/hashes/hstrlen.md
+++ b/docs/command-reference/hashes/hstrlen.md
@@ -20,7 +20,7 @@ Returns the string length of the value associated with `field` in the hash store
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the string length of the value associated with `field`, or zero when `field` is not present in the hash or `key` does not exist at all.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the string length of the value associated with `field`, or zero when `field` is not present in the hash or `key` does not exist at all.
 
 ## Examples
 

--- a/docs/command-reference/hashes/hvals.md
+++ b/docs/command-reference/hashes/hvals.md
@@ -20,7 +20,7 @@ Returns all values in the hash stored at `key`.
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): list of values in the hash, or an empty list when `key` does
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): list of values in the hash, or an empty list when `key` does
 not exist.
 
 ## Examples

--- a/docs/command-reference/hyperloglog/pfadd.md
+++ b/docs/command-reference/hyperloglog/pfadd.md
@@ -35,7 +35,7 @@ For an introduction to the HyperLogLog data structure, check the `PFCOUNT` comma
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers), specifically:
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers), specifically:
 *  1 if at least 1 HyperLogLog internal register was altered. 0 otherwise.
 
 ## Examples

--- a/docs/command-reference/hyperloglog/pfcount.md
+++ b/docs/command-reference/hyperloglog/pfcount.md
@@ -42,7 +42,7 @@ technically a write command.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers), specifically:
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers), specifically:
 *  The approximated number of unique elements observed via PFADD.
 
 ## Examples

--- a/docs/command-reference/hyperloglog/pfmerge.md
+++ b/docs/command-reference/hyperloglog/pfmerge.md
@@ -27,7 +27,7 @@ be included in the cardinality of the computed HyperLogLog.
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): The
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): The
 command just returns OK.
 
 ## Examples

--- a/docs/command-reference/json/json.arrappend.md
+++ b/docs/command-reference/json/json.arrappend.md
@@ -46,8 +46,8 @@ is JSONPath to specify. Default is root `$`.
 
 ## Return value 
 
-`JSON.ARRAPEND` returns an [array](https://redis.io/docs/reference/protocol-spec/#arrays) of integer replies for each path, the array's new size, or `nil`, if the matching JSON value is not an array. 
-For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec). 
+`JSON.ARRAPEND` returns an [array](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays) of integer replies for each path, the array's new size, or `nil`, if the matching JSON value is not an array. 
+For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec). 
 
 ## Examples
 

--- a/docs/command-reference/json/json.arrindex.md
+++ b/docs/command-reference/json/json.arrindex.md
@@ -59,8 +59,8 @@ Out-of-range indexes round to the array's start and end. An inverse index range 
 
 ## Return value 
 
-`JSON.ARRINDEX` returns an [array](https://redis.io/docs/reference/protocol-spec/#arrays) of integer replies for each path, the first position in the array of each JSON value that matches the path, `-1` if unfound in the array, or `nil`, if the matching JSON value is not an array.
-For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec). 
+`JSON.ARRINDEX` returns an [array](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays) of integer replies for each path, the first position in the array of each JSON value that matches the path, `-1` if unfound in the array, or `nil`, if the matching JSON value is not an array.
+For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec). 
 
 ## Examples
 

--- a/docs/command-reference/json/json.arrinsert.md
+++ b/docs/command-reference/json/json.arrinsert.md
@@ -51,8 +51,8 @@ is JSONPath to specify. Default is root `$`.
 
 ## Return value 
 
-`JSON.ARRINSERT` returns an [array](https://redis.io/docs/reference/protocol-spec/#arrays) of integer replies for each path, the array's new size, or `nil`, if the matching JSON value is not an array. 
-For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec). 
+`JSON.ARRINSERT` returns an [array](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays) of integer replies for each path, the array's new size, or `nil`, if the matching JSON value is not an array. 
+For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec). 
 
 ## Examples
 

--- a/docs/command-reference/json/json.arrlen.md
+++ b/docs/command-reference/json/json.arrlen.md
@@ -38,8 +38,8 @@ is JSONPath to specify. Default is root `$`, if not provided. Returns null if th
 
 ## Return
 
-`JSON.ARRLEN` returns an [array](https://redis.io/docs/reference/protocol-spec/#arrays) of integer replies, an integer for each matching value, each is the array's length, or `nil`, if the matching value is not an array.
-For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec).
+`JSON.ARRLEN` returns an [array](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays) of integer replies, an integer for each matching value, each is the array's length, or `nil`, if the matching value is not an array.
+For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec).
 
 ## Examples
 

--- a/docs/command-reference/json/json.arrpop.md
+++ b/docs/command-reference/json/json.arrpop.md
@@ -40,8 +40,8 @@ is JSONPath to specify. Default is root `$`.
 
 ## Return
 
-`JSON.ARRPOP` returns an [array](https://redis.io/docs/reference/protocol-spec/#arrays) of bulk string replies for each path, each reply is the popped JSON value, or `nil`, if the matching JSON value is not an array.
-For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec). 
+`JSON.ARRPOP` returns an [array](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays) of bulk string replies for each path, each reply is the popped JSON value, or `nil`, if the matching JSON value is not an array.
+For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec). 
 
 ## Examples
 

--- a/docs/command-reference/json/json.arrtrim.md
+++ b/docs/command-reference/json/json.arrtrim.md
@@ -59,7 +59,7 @@ Behavior as of RedisJSON v2.0:
 ## Return
 
 JSON.ARRTRIM returns an array of integer replies for each path, the array's new size, or `nil`, if the matching JSON value is not an array.
-For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec). 
+For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec). 
 
 ## Examples
 

--- a/docs/command-reference/json/json.clear.md
+++ b/docs/command-reference/json/json.clear.md
@@ -36,7 +36,7 @@ is JSONPath to specify. Default is root `$`. Nonexisting paths are ignored.
 ## Return
 
 JSON.CLEAR returns an integer reply specified as the number of values cleared. 
-For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec).
+For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec).
 
 :::note Note
 

--- a/docs/command-reference/json/json.debug-fields.md
+++ b/docs/command-reference/json/json.debug-fields.md
@@ -20,7 +20,7 @@ Report the number of fields in the JSON element.
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): a list that represents the number of fields of JSON value at each path.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): a list that represents the number of fields of JSON value at each path.
 
 ## Examples
 

--- a/docs/command-reference/json/json.debug-help.md
+++ b/docs/command-reference/json/json.debug-help.md
@@ -20,7 +20,7 @@ Return helpful information about the [`JSON.DEBUG`](./json.debug.md) command.
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): a list of helpful messages.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): a list of helpful messages.
 
 ## Examples
 

--- a/docs/command-reference/json/json.del.md
+++ b/docs/command-reference/json/json.del.md
@@ -45,7 +45,7 @@ Deleting an object's root is equivalent to deleting the key from Redis.
 ## Return
 
 JSON.DEL returns an integer reply specified as the number of paths deleted (0 or more).
-For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec).
+For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec).
 
 ## Examples
 

--- a/docs/command-reference/json/json.get.md
+++ b/docs/command-reference/json/json.get.md
@@ -81,7 +81,7 @@ JSON.GET returns a bulk string representing a JSON array of string replies.
 Each string is the JSON serialization of each JSON value that matches a path. 
 Using multiple paths, JSON.GET returns a bulk string representing a JSON object with string values. 
 Each string value is an array of the JSON serialization of each JSON value that matches a path.
-For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec).
+For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec).
 
 ## Examples
 

--- a/docs/command-reference/json/json.mget.md
+++ b/docs/command-reference/json/json.mget.md
@@ -37,7 +37,7 @@ is JSONPath to specify. Default is root `$`. Returns `null` for nonexistent path
 ## Return
 
 JSON.MGET returns an array of bulk string replies specified as the JSON serialization of the value at each key's path.
-For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec).
+For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec).
 
 ## Examples
 

--- a/docs/command-reference/json/json.numincrby.md
+++ b/docs/command-reference/json/json.numincrby.md
@@ -41,7 +41,7 @@ is JSONPath to specify. Default is root `$`.
 ## Return 
 
 JSON.NUMINCRBY returns a bulk string reply specified as a stringified new value for each path, or `nil`, if the matching JSON value is not a number. 
-For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec). 
+For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec). 
 
 ## Examples
 

--- a/docs/command-reference/json/json.nummultby.md
+++ b/docs/command-reference/json/json.nummultby.md
@@ -41,7 +41,7 @@ is JSONPath to specify. Default is root `$`.
 ## Return
 
 JSON.NUMMULTBY returns a bulk string reply specified as a stringified new values for each path, or `nil` element if the matching JSON value is not a number.
-For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec).
+For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec).
 
 ## Examples
 

--- a/docs/command-reference/json/json.objkeys.md
+++ b/docs/command-reference/json/json.objkeys.md
@@ -37,7 +37,7 @@ is JSONPath to specify. Default is root `$`. Returns `null` for nonexistant path
 ## Return
 
 JSON.OBJKEYS returns an array of array replies for each path, an array of the key names in the object as a bulk string reply, or `nil` if the matching JSON value is not an object. 
-For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec).
+For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec).
 
 ## Examples
 

--- a/docs/command-reference/json/json.objlen.md
+++ b/docs/command-reference/json/json.objlen.md
@@ -37,7 +37,7 @@ is JSONPath to specify. Default is root `$`. Returns `null` for nonexistant path
 ## Return
 
 JSON.OBJLEN returns an array of integer replies for each path specified as the number of keys in the object or `nil`, if the matching JSON value is not an object.
-For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec).
+For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec).
 
 ## Examples
 

--- a/docs/command-reference/json/json.resp.md
+++ b/docs/command-reference/json/json.resp.md
@@ -15,7 +15,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **ACL categories:** @json
 
-Return the JSON in `key` in [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec) form 
+Return the JSON in `key` in [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec) form 
 
 [Examples](#examples)
 
@@ -39,12 +39,12 @@ is JSONPath to specify. Default is root `$`. This command uses the following map
 *   JSON array is represented as an array reply in which the first element is the simple string reply `[`, followed by the array's elements.
 *   JSON object is represented as an array reply in which the first element is the simple string reply `{`. Each successive entry represents a key-value pair as a two-entry array reply of the bulk string reply.
 
-For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec).
+For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec).
 </details>
 
 ## Return
 
-JSON.RESP returns an array reply specified as the JSON's RESP form detailed in [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec).
+JSON.RESP returns an array reply specified as the JSON's RESP form detailed in [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec).
 
 ## Examples
 

--- a/docs/command-reference/json/json.set.md
+++ b/docs/command-reference/json/json.set.md
@@ -53,7 +53,7 @@ sets the key only if it already exists.
 ## Return value
 
 JSET.SET returns a simple string reply: `OK` if executed correctly or `nil` if the specified `NX` or `XX` conditions were not met.
-For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec).
+For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec).
 
 ## Examples
 

--- a/docs/command-reference/json/json.strappend.md
+++ b/docs/command-reference/json/json.strappend.md
@@ -47,7 +47,7 @@ is JSONPath to specify. Default is root `$`.
 ## Return value 
 
 JSON.STRAPPEND returns an array of integer replies for each path, the string's new length, or `nil`, if the matching JSON value is not a string.
-For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec). 
+For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec). 
 
 ## Examples
 

--- a/docs/command-reference/json/json.strlen.md
+++ b/docs/command-reference/json/json.strlen.md
@@ -36,7 +36,7 @@ is JSONPath to specify. Default is root `$`, if not provided. Returns null if th
 ## Return
 
 JSON.STRLEN returns by recursive descent an array of integer replies for each path, the array's length, or `nil`, if the matching JSON value is not a string.
-For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec). 
+For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec). 
 
 ## Examples
 

--- a/docs/command-reference/json/json.toggle.md
+++ b/docs/command-reference/json/json.toggle.md
@@ -37,7 +37,7 @@ is JSONPath to specify. Default is root `$`.
 ## Return
 
 JSON.TOGGLE returns an array of integer replies for each path, the new value (`0` if `false` or `1` if `true`), or `nil` for JSON values matching the path that are not Boolean.
-For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec).
+For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec).
 
 ## Examples
 

--- a/docs/command-reference/json/json.type.md
+++ b/docs/command-reference/json/json.type.md
@@ -37,7 +37,7 @@ is JSONPath to specify. Default is root `$`. Returns null if the `key` or `path`
 ## Return
 
 JSON.TYPE returns an array of string replies for each path, specified as the value's type.
-For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec).
+For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/latest/develop/reference/protocol-spec).
 
 ## Examples
 

--- a/docs/command-reference/lists/blpop.md
+++ b/docs/command-reference/lists/blpop.md
@@ -120,7 +120,7 @@ If you like science fiction, think of time flowing at infinite speed inside a
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): specifically:
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): specifically:
 
 * A `nil` multi-bulk when no element could be popped and the timeout expired.
 * A two-element multi-bulk with the first element being the name of the key

--- a/docs/command-reference/lists/brpop.md
+++ b/docs/command-reference/lists/brpop.md
@@ -29,7 +29,7 @@ the tail of a list instead of popping from the head.
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): specifically:
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): specifically:
 
 * A `nil` multi-bulk when no element could be popped and the timeout expired.
 * A two-element multi-bulk with the first element being the name of the key

--- a/docs/command-reference/lists/brpoplpush.md
+++ b/docs/command-reference/lists/brpoplpush.md
@@ -25,8 +25,8 @@ See `RPOPLPUSH` for more information.
 
 ## Return
 
-[Bulk string reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings): the element being popped from `source` and pushed to `destination`.
-If `timeout` is reached, a [Null reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings) is returned.
+[Bulk string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings): the element being popped from `source` and pushed to `destination`.
+If `timeout` is reached, a [Null reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings) is returned.
 
 ## Pattern: Reliable queue
 

--- a/docs/command-reference/lists/lindex.md
+++ b/docs/command-reference/lists/lindex.md
@@ -26,7 +26,7 @@ When the value at `key` is not a list, an error is returned.
 
 ## Return
 
-[Bulk string reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings): the requested element, or `nil` when `index` is out of range.
+[Bulk string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings): the requested element, or `nil` when `index` is out of range.
 
 ## Examples
 

--- a/docs/command-reference/lists/linsert.md
+++ b/docs/command-reference/lists/linsert.md
@@ -25,7 +25,7 @@ An error is returned when `key` exists but does not hold a list value.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the list length after a successful insert operation, `0` if the `key` doesn't exist, and `-1` when the `pivot` wasn't found.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the list length after a successful insert operation, `0` if the `key` doesn't exist, and `-1` when the `pivot` wasn't found.
 
 ## Examples
 

--- a/docs/command-reference/lists/llen.md
+++ b/docs/command-reference/lists/llen.md
@@ -21,7 +21,7 @@ An error is returned when the value stored at `key` is not a list.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the length of the list at `key`.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the length of the list at `key`.
 
 ## Examples
 

--- a/docs/command-reference/lists/lmove.md
+++ b/docs/command-reference/lists/lmove.md
@@ -37,7 +37,7 @@ This command comes in place of the now deprecated `RPOPLPUSH`. Doing
 
 ## Return
 
-[Bulk string reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings): the element being popped and pushed.
+[Bulk string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings): the element being popped and pushed.
 
 ## Examples
 

--- a/docs/command-reference/lists/lmpop.md
+++ b/docs/command-reference/lists/lmpop.md
@@ -21,7 +21,7 @@ Elements are popped from either the left or right of the first non-empty list ba
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): specifically:
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): specifically:
 
 * `nil` when no element could be popped.
 * A two-element array with the first element being the name of the key from which elements were popped and the second element being an array of elements.

--- a/docs/command-reference/lists/lpop.md
+++ b/docs/command-reference/lists/lpop.md
@@ -25,11 +25,11 @@ to `count` elements, depending on the list's length.
 
 When called without the `count` argument:
 
-[Bulk string reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings): the value of the first element, or `nil` when `key` does not exist.
+[Bulk string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings): the value of the first element, or `nil` when `key` does not exist.
 
 When called with the `count` argument:
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): list of popped elements, or `nil` when `key` does not exist.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): list of popped elements, or `nil` when `key` does not exist.
 
 ## Examples
 

--- a/docs/command-reference/lists/lpush.md
+++ b/docs/command-reference/lists/lpush.md
@@ -29,7 +29,7 @@ containing `c` as first element, `b` as second element and `a` as third element.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the length of the list after the push operations.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the length of the list after the push operations.
 
 ## Examples
 

--- a/docs/command-reference/lists/lpushx.md
+++ b/docs/command-reference/lists/lpushx.md
@@ -22,7 +22,7 @@ exist.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the length of the list after the push operation.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the length of the list after the push operation.
 
 ## Examples
 

--- a/docs/command-reference/lists/lrange.md
+++ b/docs/command-reference/lists/lrange.md
@@ -42,7 +42,7 @@ the last element of the list.
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): list of elements in the specified range.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): list of elements in the specified range.
 
 ## Examples
 

--- a/docs/command-reference/lists/lrem.md
+++ b/docs/command-reference/lists/lrem.md
@@ -31,7 +31,7 @@ exist, the command will always return `0`.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the number of removed elements.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the number of removed elements.
 
 ## Examples
 

--- a/docs/command-reference/lists/lset.md
+++ b/docs/command-reference/lists/lset.md
@@ -22,7 +22,7 @@ An error is returned for out of range indexes.
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings)
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings)
 
 ## Examples
 

--- a/docs/command-reference/lists/ltrim.md
+++ b/docs/command-reference/lists/ltrim.md
@@ -48,7 +48,7 @@ is removed from the tail of the list.
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings)
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings)
 
 ## Examples
 

--- a/docs/command-reference/lists/rpop.md
+++ b/docs/command-reference/lists/rpop.md
@@ -25,11 +25,11 @@ to `count` elements, depending on the list's length.
 
 When called without the `count` argument:
 
-[Bulk string reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings): the value of the last element, or `nil` when `key` does not exist.
+[Bulk string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings): the value of the last element, or `nil` when `key` does not exist.
 
 When called with the `count` argument:
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): list of popped elements, or `nil` when `key` does not exist.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): list of popped elements, or `nil` when `key` does not exist.
 
 ## Examples
 

--- a/docs/command-reference/lists/rpoplpush.md
+++ b/docs/command-reference/lists/rpoplpush.md
@@ -32,7 +32,7 @@ list, so it can be considered as a list rotation command.
 
 ## Return
 
-[Bulk string reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings): the element being popped and pushed.
+[Bulk string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings): the element being popped and pushed.
 
 ## Examples
 

--- a/docs/command-reference/lists/rpush.md
+++ b/docs/command-reference/lists/rpush.md
@@ -29,7 +29,7 @@ containing `a` as first element, `b` as second element and `c` as third element.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the length of the list after the push operation.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the length of the list after the push operation.
 
 ## Examples
 

--- a/docs/command-reference/lists/rpushx.md
+++ b/docs/command-reference/lists/rpushx.md
@@ -22,7 +22,7 @@ exist.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the length of the list after the push operation.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the length of the list after the push operation.
 
 ## Examples
 

--- a/docs/command-reference/pubsub/_unsupported/xgroup-create.md
+++ b/docs/command-reference/pubsub/_unsupported/xgroup-create.md
@@ -38,4 +38,4 @@ Set the `entries_read` the stream's `entries_added` subtracted by the number of 
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): `OK` on success.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): `OK` on success.

--- a/docs/command-reference/pubsub/_unsupported/xgroup-createconsumer.md
+++ b/docs/command-reference/pubsub/_unsupported/xgroup-createconsumer.md
@@ -21,4 +21,4 @@ This is valid for `XREADGROUP` only when there is data in the stream.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the number of created consumers (0 or 1)
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the number of created consumers (0 or 1)

--- a/docs/command-reference/pubsub/_unsupported/xgroup-delconsumer.md
+++ b/docs/command-reference/pubsub/_unsupported/xgroup-delconsumer.md
@@ -23,4 +23,4 @@ It is strongly recommended, therefore, that any pending messages are claimed or 
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the number of pending messages that the consumer had before it was deleted
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the number of pending messages that the consumer had before it was deleted

--- a/docs/command-reference/pubsub/_unsupported/xgroup-destroy.md
+++ b/docs/command-reference/pubsub/_unsupported/xgroup-destroy.md
@@ -20,4 +20,4 @@ The consumer group will be destroyed even if there are active consumers, and pen
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the number of destroyed consumer groups (0 or 1)
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the number of destroyed consumer groups (0 or 1)

--- a/docs/command-reference/pubsub/_unsupported/xgroup-help.md
+++ b/docs/command-reference/pubsub/_unsupported/xgroup-help.md
@@ -18,4 +18,4 @@ The `XGROUP HELP` command returns a helpful text describing the different subcom
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): a list of subcommands and their descriptions
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): a list of subcommands and their descriptions

--- a/docs/command-reference/pubsub/_unsupported/xgroup-setid.md
+++ b/docs/command-reference/pubsub/_unsupported/xgroup-setid.md
@@ -29,4 +29,4 @@ In such cases, the `entries_read` can be set to the stream's `entries_added` sub
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): `OK` on success.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): `OK` on success.

--- a/docs/command-reference/pubsub/_unsupported/xinfo-consumers.md
+++ b/docs/command-reference/pubsub/_unsupported/xinfo-consumers.md
@@ -23,7 +23,7 @@ The following information is provided for each consumer in the group:
 
 @reply
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): a list of consumers.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): a list of consumers.
 
 ## Examples
 

--- a/docs/command-reference/pubsub/_unsupported/xinfo-groups.md
+++ b/docs/command-reference/pubsub/_unsupported/xinfo-groups.md
@@ -56,7 +56,7 @@ Once the consumer group delivers the last message in the stream to its members, 
 
 @reply
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): a list of consumer groups.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): a list of consumer groups.
 
 ## Examples
 

--- a/docs/command-reference/pubsub/_unsupported/xinfo-help.md
+++ b/docs/command-reference/pubsub/_unsupported/xinfo-help.md
@@ -18,4 +18,4 @@ The `XINFO HELP` command returns a helpful text describing the different subcomm
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): a list of subcommands and their descriptions
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): a list of subcommands and their descriptions

--- a/docs/command-reference/pubsub/_unsupported/xinfo-stream.md
+++ b/docs/command-reference/pubsub/_unsupported/xinfo-stream.md
@@ -36,7 +36,7 @@ The default `COUNT` is 10 and a `COUNT` of 0 means that all entries will be retu
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): a list of informational bits
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): a list of informational bits
 
 ## Examples
 

--- a/docs/command-reference/pubsub/publish.md
+++ b/docs/command-reference/pubsub/publish.md
@@ -19,7 +19,7 @@ Posts a message to the given channel.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the number of clients that received the message. 
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the number of clients that received the message. 
 
 ## Examples
 

--- a/docs/command-reference/pubsub/pubsub-channels.md
+++ b/docs/command-reference/pubsub/pubsub-channels.md
@@ -23,7 +23,7 @@ If no `pattern` is specified, all the channels are listed, otherwise if pattern 
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): a list of active channels, optionally matching the specified pattern.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): a list of active channels, optionally matching the specified pattern.
 
 ## Examples
 

--- a/docs/command-reference/pubsub/pubsub-help.md
+++ b/docs/command-reference/pubsub/pubsub-help.md
@@ -19,4 +19,4 @@ The `PUBSUB HELP` command returns a helpful text describing the different subcom
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): a list of subcommands and their descriptions
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): a list of subcommands and their descriptions

--- a/docs/command-reference/pubsub/pubsub-numpat.md
+++ b/docs/command-reference/pubsub/pubsub-numpat.md
@@ -21,4 +21,4 @@ Note that this isn't the count of clients subscribed to patterns, but the total 
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the number of patterns all the clients are subscribed to.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the number of patterns all the clients are subscribed to.

--- a/docs/command-reference/pubsub/pubsub-numsub.md
+++ b/docs/command-reference/pubsub/pubsub-numsub.md
@@ -23,6 +23,6 @@ Cluster note: in a Redis Cluster clients can subscribe to every node, and can al
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): a list of channels and number of subscribers for every channel.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): a list of channels and number of subscribers for every channel.
 
 The format is channel, count, channel, count, ..., so the list is flat. The order in which the channels are listed is the same as the order of the channels specified in the command call.

--- a/docs/command-reference/pubsub/pubsub-shardchannels.md
+++ b/docs/command-reference/pubsub/pubsub-shardchannels.md
@@ -25,7 +25,7 @@ The information returned about the active shard channels are at the shard level 
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): a list of active channels, optionally matching the specified pattern.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): a list of active channels, optionally matching the specified pattern.
 
 ## Examples
 

--- a/docs/command-reference/pubsub/pubsub-shardnumsub.md
+++ b/docs/command-reference/pubsub/pubsub-shardnumsub.md
@@ -23,7 +23,7 @@ Cluster note: in a Redis Cluster, `PUBSUB`'s replies in a cluster only report in
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): a list of channels and number of subscribers for every channel.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): a list of channels and number of subscribers for every channel.
 
 The format is channel, count, channel, count, ..., so the list is flat. The order in which the channels are listed is the same as the order of the shard channels specified in the command call.
 

--- a/docs/command-reference/pubsub/spublish.md
+++ b/docs/command-reference/pubsub/spublish.md
@@ -22,7 +22,7 @@ complete, clients get redirected to thew new node that owns the moved slot to co
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the number of clients that received the message. 
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the number of clients that received the message. 
 
 ## Examples
 

--- a/docs/command-reference/rate-limiter/cl.throttle.md
+++ b/docs/command-reference/rate-limiter/cl.throttle.md
@@ -48,7 +48,7 @@ dragonfly$> CL.THROTTLE user123 20 120 60 1
 
 ## Return Values
 
-An [array](https://redis.io/docs/reference/protocol-spec/#arrays) of 5 integers with the following values:
+An [array](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays) of 5 integers with the following values:
 
 1. Whether to limit the related action (0 for allowed, 1 for limited).
 2. The total limit of the key. (Equivalent to `X-RateLimit-Limit`)

--- a/docs/command-reference/search/ft._list.md
+++ b/docs/command-reference/search/ft._list.md
@@ -19,7 +19,7 @@ In the future, a `SCAN` type of command will be added for use when a database co
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec#arrays) with index names.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec#arrays) with index names.
 
 ## Examples
 

--- a/docs/command-reference/server-management/auth.md
+++ b/docs/command-reference/server-management/auth.md
@@ -31,4 +31,4 @@ strong and very long password so that this attack is infeasible.
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings) or an error if the password is invalid.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings) or an error if the password is invalid.

--- a/docs/command-reference/server-management/bgsave.md
+++ b/docs/command-reference/server-management/bgsave.md
@@ -23,4 +23,4 @@ Equvalent to [SAVE](../server-management/save) and kept for compatibility reason
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): `Background saving started` if `BGSAVE` started correctly or `Background saving scheduled` when used with the `SCHEDULE` subcommand. 
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): `Background saving started` if `BGSAVE` started correctly or `Background saving scheduled` when used with the `SCHEDULE` subcommand. 

--- a/docs/command-reference/server-management/client-getname.md
+++ b/docs/command-reference/server-management/client-getname.md
@@ -20,4 +20,4 @@ The `CLIENT GETNAME` returns the name of the current connection as set by `CLIEN
 
 ## Return
 
-[Bulk string reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings): The connection name, or a null bulk reply if no name is set.
+[Bulk string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings): The connection name, or a null bulk reply if no name is set.

--- a/docs/command-reference/server-management/client-list.md
+++ b/docs/command-reference/server-management/client-list.md
@@ -22,7 +22,7 @@ connections server in a mostly human readable format.
 
 ## Return
 
-[Bulk string reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings): a unique string, formatted as follows:
+[Bulk string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings): a unique string, formatted as follows:
 
 * One client connection per line (separated by LF)
 * Each line is composed of a succession of `property=value` fields separated

--- a/docs/command-reference/server-management/client-setname.md
+++ b/docs/command-reference/server-management/client-setname.md
@@ -34,4 +34,4 @@ Tip: setting names to connections is a good way to debug connection leaks due to
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): `OK` if the connection name was successfully set.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): `OK` if the connection name was successfully set.

--- a/docs/command-reference/server-management/client-tracking.md
+++ b/docs/command-reference/server-management/client-tracking.md
@@ -31,7 +31,7 @@ and Dragonfly stops tracking the keys for the connection, and no invalidation me
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): `OK` if the connection was
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): `OK` if the connection was
 successfully put in tracking mode or if the tracking mode was successfully disabled. Otherwise, an error is returned.
 
 ## Options

--- a/docs/command-reference/server-management/command-count.md
+++ b/docs/command-reference/server-management/command-count.md
@@ -16,11 +16,11 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **ACL categories:** @slow, @connection
 
-Returns [Integer reply](https://redis.io/docs/reference/protocol-spec/#integers) of number of total commands in this Dragonfly server.
+Returns [Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers) of number of total commands in this Dragonfly server.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): number of commands returned by `COMMAND`
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): number of commands returned by `COMMAND`
 
 ## Examples
 

--- a/docs/command-reference/server-management/command.md
+++ b/docs/command-reference/server-management/command.md
@@ -122,7 +122,7 @@ Unlike `MGET`, which uses a step value of _1_.
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): a nested list of command details.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): a nested list of command details.
 
 The order of commands in the array is random.
 

--- a/docs/command-reference/server-management/config-get.md
+++ b/docs/command-reference/server-management/config-get.md
@@ -25,7 +25,7 @@ Any configuration parameters matching the pattern are reported as a list of key-
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): list of key-value pairs for configuration parameters.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): list of key-value pairs for configuration parameters.
 
 ## Examples
 

--- a/docs/command-reference/server-management/config-resetstat.md
+++ b/docs/command-reference/server-management/config-resetstat.md
@@ -20,4 +20,4 @@ Resets the statistics reported by Dragonfly using the `INFO` command.
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): always `OK`.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): always `OK`.

--- a/docs/command-reference/server-management/config-set.md
+++ b/docs/command-reference/server-management/config-set.md
@@ -26,7 +26,7 @@ Note we only support configuring a single parameter at a time.
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): `OK` when the configuration was set properly, error otherwise.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): `OK` when the configuration was set properly, error otherwise.
 
 ## Examples
 

--- a/docs/command-reference/server-management/dbsize.md
+++ b/docs/command-reference/server-management/dbsize.md
@@ -20,4 +20,4 @@ Return the number of keys in the currently-selected database.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers)
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers)

--- a/docs/command-reference/server-management/echo.md
+++ b/docs/command-reference/server-management/echo.md
@@ -20,7 +20,7 @@ Returns `message`.
 
 ## Return
 
-[Bulk string reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings)
+[Bulk string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings)
 
 ## Examples
 

--- a/docs/command-reference/server-management/flushall.md
+++ b/docs/command-reference/server-management/flushall.md
@@ -23,4 +23,4 @@ Note: an asynchronous `FLUSHALL` command only deletes keys that were present at 
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings)
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings)

--- a/docs/command-reference/server-management/flushdb.md
+++ b/docs/command-reference/server-management/flushdb.md
@@ -23,4 +23,4 @@ Note: an asynchronous `FLUSHDB` command only deletes keys that were present at t
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings)
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings)

--- a/docs/command-reference/server-management/hello.md
+++ b/docs/command-reference/server-management/hello.md
@@ -68,4 +68,4 @@ When called with the optional protover argument, this command switches the proto
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): a list of server properties. The reply is a map instead of an array when RESP3 is selected. The command returns an error if the protover requested does not exist.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): a list of server properties. The reply is a map instead of an array when RESP3 is selected. The command returns an error if the protover requested does not exist.

--- a/docs/command-reference/server-management/info.md
+++ b/docs/command-reference/server-management/info.md
@@ -40,7 +40,7 @@ When no parameter is provided, the `default` option is assumed.
 
 ## Return
 
-[Bulk string reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings): as a collection of text lines.
+[Bulk string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings): as a collection of text lines.
 
 Lines can contain a section name (starting with a # character) or a property.
 All the properties are in the form of `field:value` terminated by `\r\n`.

--- a/docs/command-reference/server-management/lastsave.md
+++ b/docs/command-reference/server-management/lastsave.md
@@ -23,4 +23,4 @@ seconds if `LASTSAVE` changed. Dragonfly considers the database saved successful
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): an UNIX time stamp.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): an UNIX time stamp.

--- a/docs/command-reference/server-management/memory-help.md
+++ b/docs/command-reference/server-management/memory-help.md
@@ -21,4 +21,4 @@ subcommands.
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): a list of subcommands and their descriptions
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): a list of subcommands and their descriptions

--- a/docs/command-reference/server-management/memory-malloc-stats.md
+++ b/docs/command-reference/server-management/memory-malloc-stats.md
@@ -21,4 +21,4 @@ the memory allocator.
 
 ## Return
 
-[Bulk string reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings): the memory allocator's internal statistics report
+[Bulk string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings): the memory allocator's internal statistics report

--- a/docs/command-reference/server-management/ping.md
+++ b/docs/command-reference/server-management/ping.md
@@ -30,9 +30,9 @@ of the argument.
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings), and specifically `PONG`, when no argument is provided.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings), and specifically `PONG`, when no argument is provided.
 
-[Bulk string reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings) the argument provided, when applicable.
+[Bulk string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings) the argument provided, when applicable.
 
 ## Examples
 

--- a/docs/command-reference/server-management/quit.md
+++ b/docs/command-reference/server-management/quit.md
@@ -26,4 +26,4 @@ Terminating a connection on the client side is preferable, as it eliminates `TIM
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): always OK.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): always OK.

--- a/docs/command-reference/server-management/replicaof.md
+++ b/docs/command-reference/server-management/replicaof.md
@@ -29,7 +29,7 @@ Later when the other Dragonfly server is fixed, it can be reconfigured to work a
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings)
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings)
 
 ## Examples
 

--- a/docs/command-reference/server-management/role.md
+++ b/docs/command-reference/server-management/role.md
@@ -65,4 +65,4 @@ The replica output is composed of the following parts:
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): where the first element is one of `master`, `slave`, `sentinel` and the additional elements are role-specific as illustrated above.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): where the first element is one of `master`, `slave`, `sentinel` and the additional elements are role-specific as illustrated above.

--- a/docs/command-reference/server-management/save.md
+++ b/docs/command-reference/server-management/save.md
@@ -40,7 +40,7 @@ Optional argument `filename` is used to override current **`dbfilename`** for sa
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): The commands returns OK on success.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): The commands returns OK on success.
 
 ## Examples
 

--- a/docs/command-reference/server-management/select.md
+++ b/docs/command-reference/server-management/select.md
@@ -26,4 +26,4 @@ In practical terms, Dragonfly databases should be used to separate different key
 Since the currently selected database is a property of the connection, clients should track the currently selected database and re-select it on reconnection.
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings)
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings)

--- a/docs/command-reference/server-management/shutdown.md
+++ b/docs/command-reference/server-management/shutdown.md
@@ -41,6 +41,6 @@ See also [Signal Handling](https://redis.io/topics/signals).
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): `OK` if `ABORT` was specified and shutdown was aborted.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): `OK` if `ABORT` was specified and shutdown was aborted.
 On successful shutdown, nothing is returned since the server quits and the connection is closed.
 On failure, an error is returned.

--- a/docs/command-reference/server-management/slowlog-get.md
+++ b/docs/command-reference/server-management/slowlog-get.md
@@ -38,4 +38,4 @@ restart will reset it.
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): a list of slow log entries.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): a list of slow log entries.

--- a/docs/command-reference/server-management/slowlog-help.md
+++ b/docs/command-reference/server-management/slowlog-help.md
@@ -16,4 +16,4 @@ The `SLOWLOG HELP` command returns a helpful text describing the different subco
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): a list of subcommands and their descriptions.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): a list of subcommands and their descriptions.

--- a/docs/command-reference/server-management/slowlog-len.md
+++ b/docs/command-reference/server-management/slowlog-len.md
@@ -20,4 +20,4 @@ The slow log can be cleared with the `SLOWLOG RESET` command.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): The number of entries in the slow log.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): The number of entries in the slow log.

--- a/docs/command-reference/server-management/slowlog-reset.md
+++ b/docs/command-reference/server-management/slowlog-reset.md
@@ -17,4 +17,4 @@ Once deleted the information is lost forever.
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/reference/protocol-spec/#simple-strings): `OK`
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): `OK`

--- a/docs/command-reference/server-management/time.md
+++ b/docs/command-reference/server-management/time.md
@@ -23,7 +23,7 @@ call.
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays), specifically:
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays), specifically:
 
 A multi bulk reply containing two elements:
 

--- a/docs/command-reference/sets/sadd.md
+++ b/docs/command-reference/sets/sadd.md
@@ -25,7 +25,7 @@ An error is returned when the value stored at `key` is not a set.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the number of elements that were added to the set, not including
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the number of elements that were added to the set, not including
 all the elements already present in the set.
 
 ## Examples

--- a/docs/command-reference/sets/saddex.md
+++ b/docs/command-reference/sets/saddex.md
@@ -27,7 +27,7 @@ An error is returned when the value stored at `key` is not a set.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the number of elements that were added to the set, not including all the elements already present in the set.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the number of elements that were added to the set, not including all the elements already present in the set.
 
 ## Examples
 

--- a/docs/command-reference/sets/scard.md
+++ b/docs/command-reference/sets/scard.md
@@ -20,7 +20,7 @@ Returns the set cardinality (number of elements) of the set stored at `key`.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the cardinality (number of elements) of the set, or `0` if `key`
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the cardinality (number of elements) of the set, or `0` if `key`
 does not exist.
 
 ## Examples

--- a/docs/command-reference/sets/sdiff.md
+++ b/docs/command-reference/sets/sdiff.md
@@ -32,7 +32,7 @@ Keys that do not exist are considered to be empty sets.
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): list with members of the resulting set.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): list with members of the resulting set.
 
 ## Examples
 

--- a/docs/command-reference/sets/sdiffstore.md
+++ b/docs/command-reference/sets/sdiffstore.md
@@ -23,7 +23,7 @@ If `destination` already exists, it is overwritten.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the number of elements in the resulting set.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the number of elements in the resulting set.
 
 ## Examples
 

--- a/docs/command-reference/sets/sinter.md
+++ b/docs/command-reference/sets/sinter.md
@@ -34,7 +34,7 @@ set intersection with an empty set always results in an empty set).
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): list with members of the resulting set.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): list with members of the resulting set.
 
 ## Examples
 

--- a/docs/command-reference/sets/sinterstore.md
+++ b/docs/command-reference/sets/sinterstore.md
@@ -23,7 +23,7 @@ If `destination` already exists, it is overwritten.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the number of elements in the resulting set.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the number of elements in the resulting set.
 
 ## Examples
 

--- a/docs/command-reference/sets/sismember.md
+++ b/docs/command-reference/sets/sismember.md
@@ -20,7 +20,7 @@ Returns if `member` is a member of the set stored at `key`.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers), specifically:
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers), specifically:
 
 * `1` if the element is a member of the set.
 * `0` if the element is not a member of the set, or if `key` does not exist.

--- a/docs/command-reference/sets/smembers.md
+++ b/docs/command-reference/sets/smembers.md
@@ -22,7 +22,7 @@ This has the same effect as running `SINTER` with one argument `key`.
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): all elements of the set.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): all elements of the set.
 
 ## Examples
 

--- a/docs/command-reference/sets/smismember.md
+++ b/docs/command-reference/sets/smismember.md
@@ -22,7 +22,7 @@ For every `member`, `1` is returned if the value is a member of the set, or `0` 
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): list representing the membership of the given elements, in the same
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): list representing the membership of the given elements, in the same
 order as they are requested.
 
 ## Examples

--- a/docs/command-reference/sets/smove.md
+++ b/docs/command-reference/sets/smove.md
@@ -32,7 +32,7 @@ An error is returned if `source` or `destination` does not hold a set value.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers), specifically:
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers), specifically:
 
 * `1` if the element is moved.
 * `0` if the element is not a member of `source` and no operation was performed.

--- a/docs/command-reference/sets/spop.md
+++ b/docs/command-reference/sets/spop.md
@@ -28,11 +28,11 @@ depending on the set's cardinality.
 
 When called without the `count` argument:
 
-[Bulk string reply](https://redis.io/docs/reference/protocol-spec/#bulk-strings): the removed member, or `nil` when `key` does not exist.
+[Bulk string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#bulk-strings): the removed member, or `nil` when `key` does not exist.
 
 When called with the `count` argument:
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): the removed members, or an empty array when `key` does not exist.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): the removed members, or an empty array when `key` does not exist.
 
 ## Examples
 

--- a/docs/command-reference/sets/srem.md
+++ b/docs/command-reference/sets/srem.md
@@ -25,7 +25,7 @@ An error is returned when the value stored at `key` is not a set.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the number of members that were removed from the set, not
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the number of members that were removed from the set, not
 including non existing members.
 
 ## Examples

--- a/docs/command-reference/sets/sunion.md
+++ b/docs/command-reference/sets/sunion.md
@@ -31,7 +31,7 @@ Keys that do not exist are considered to be empty sets.
 
 ## Return
 
-[Array reply](https://redis.io/docs/reference/protocol-spec/#arrays): list with members of the resulting set.
+[Array reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays): list with members of the resulting set.
 
 ## Examples
 

--- a/docs/command-reference/sets/sunionstore.md
+++ b/docs/command-reference/sets/sunionstore.md
@@ -23,7 +23,7 @@ If `destination` already exists, it is overwritten.
 
 ## Return
 
-[Integer reply](https://redis.io/docs/reference/protocol-spec/#integers): the number of elements in the resulting set.
+[Integer reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#integers): the number of elements in the resulting set.
 
 ## Examples
 

--- a/docs/command-reference/strings/cl.throttle.md
+++ b/docs/command-reference/strings/cl.throttle.md
@@ -48,7 +48,7 @@ dragonfly$> CL.THROTTLE user123 20 120 60 1
 
 ## Return Values
 
-An [array](https://redis.io/docs/reference/protocol-spec/#arrays) of 5 integers with the following values:
+An [array](https://redis.io/docs/latest/develop/reference/protocol-spec/#arrays) of 5 integers with the following values:
 
 1. Whether to limit the related action (0 for allowed, 1 for limited).
 2. The total limit of the key. (Equivalent to `X-RateLimit-Limit`)

--- a/scripts/pull-redis-docs.ts
+++ b/scripts/pull-redis-docs.ts
@@ -85,15 +85,15 @@ const getCommandsConfigFromZip = (zip: AdmZip): Record<string, CommandConfig> =>
 const specialSyntaxes = {
   return: "## Return",
   examples: "## Examples",
-  "nil-reply": "[Null reply](/docs/reference/protocol-spec#resp-bulk-strings)",
+  "nil-reply": "[Null reply](/docs/latest/develop/reference/protocol-spec#resp-bulk-strings)",
   "simple-string-reply":
-    "[Simple string reply](/docs/reference/protocol-spec#resp-simple-strings)",
+    "[Simple string reply](/docs/latest/develop/reference/protocol-spec#resp-simple-strings)",
   "integer-reply":
-    "[Integer reply](/docs/reference/protocol-spec#resp-integers)",
+    "[Integer reply](/docs/latest/develop/reference/protocol-spec#resp-integers)",
   "bulk-string-reply":
-    "[Bulk string reply](/docs/reference/protocol-spec#resp-bulk-strings)",
-  "array-reply": "[Array reply](/docs/reference/protocol-spec#resp-arrays)",
-  "error-reply": "[Error reply](/docs/reference/protocol-spec#resp-errors)",
+    "[Bulk string reply](/docs/latest/develop/reference/protocol-spec#resp-bulk-strings)",
+  "array-reply": "[Array reply](/docs/latest/develop/reference/protocol-spec#resp-arrays)",
+  "error-reply": "[Error reply](/docs/latest/develop/reference/protocol-spec#resp-errors)",
 };
 
 const processMdSpecialSyntax = (mdContent: string) =>


### PR DESCRIPTION
https://redis.io/docs/reference/protocol-spec moved to https://redis.io/docs/latest/develop/reference/protocol-spec