### PR TITLE
docs: Add doc for client caching command

### DIFF
--- a/docs/command-reference/server-management/client-caching.md
+++ b/docs/command-reference/server-management/client-caching.md
@@ -54,7 +54,7 @@ dragonfly> GET user_count
 "100"
 
 # Change client tracking mode.
-dragonfly> CLIENT TRACKING OFF OPTIN
+dragonfly> CLIENT TRACKING ON OPTIN
 OK
 
 # The next command will be cached.

--- a/docs/command-reference/server-management/client-caching.md
+++ b/docs/command-reference/server-management/client-caching.md
@@ -23,7 +23,7 @@ The `CLIENT CACHING` command changes tracking of keys **only for the next comman
 When tracking is enabled using [`CLIENT TRACKING`](./client-tracking.md), it is possible to specify `OPTIN` or `OPTOUT` options,
 so that keys in read-only commands are not automatically remembered by the server to be invalidated later.
 
-- When the client is in `OFF OPTIN` mode, the standard behavior is to not track keys.
+- When the client is in `OPTIN` mode, the standard behavior is to not track keys.
   The client can force tracking of the keys used in the next command by calling `CLIENT CACHING YES` before the command.
 - Similarly, when the client is in `ON OPTOUT` mode, the standard behavior is to track keys.
   This behavior can be overridden for keys used in the next command by calling `CLIENT CACHING NO` before the command.

--- a/docs/command-reference/server-management/client-caching.md
+++ b/docs/command-reference/server-management/client-caching.md
@@ -34,7 +34,7 @@ Again, the behavior change enforced by the `CLIENT CACHING` command is only appl
 
 [Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): `OK` if the argument is valid.
 An error is returned if RESP3 is not enabled, or the argument does not match the current tracking mode for the client.
-For example, if `YES` is specified when the mode is not `OFF OPTIN`, or `NO` is specified when the mode is not `ON OPTOUT`.
+For example, if `YES` is specified when the mode is not `OPTIN`, or `NO` is specified when the mode is not `OPTOUT`.
 
 ## Examples
 

--- a/docs/command-reference/server-management/client-caching.md
+++ b/docs/command-reference/server-management/client-caching.md
@@ -18,40 +18,46 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Important**: Only available when the [RESP3](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md) protocol is used.
 
-The `CLIENT CACHING` command changes tracking of keys only for the next command executed by the connection. See more details about tracking in the [documentation](https://www.dragonflydb.io/docs/command-reference/server-management/client-tracking) for the tracking command.
+The `CLIENT CACHING` command changes tracking of keys **only for the next command executed by the connection**.
 
-When tracking is enabled using [CLIENT TRACKING](https://www.dragonflydb.io/docs/command-reference/server-management/client-tracking), it is possible to specify `OPTIN`
-or `OPTOUT` options, so that for example keys in read only commands are not remembered by the server.
+When tracking is enabled using [`CLIENT TRACKING`](./client-tracking.md), it is possible to specify `OPTIN` or `OPTOUT` options,
+so that keys in read-only commands are not automatically remembered by the server to be invalidated later.
 
-When the client is in `OFF OPTIN` mode the standard behavior is to not track keys, the client can force tracking of the keys used in the next command by calling `CLIENT CACHING YES` before the command.
+- When the client is in `OFF OPTIN` mode, the standard behavior is to not track keys.
+  The client can force tracking of the keys used in the next command by calling `CLIENT CACHING YES` before the command.
+- Similarly, when the client is in `ON OPTOUT` mode, the standard behavior is to track keys.
+  This behavior can be overridden for keys used in the next command by calling `CLIENT CACHING NO` before the command.
 
-Similarly, when the client is in `ON OPTOUT` mode, the standard behavior is to track keys. This behavior can be overridden for keys used in the next command by calling `CLIENT CACHING NO` before the command.
-
-The behavior change enforced by the `CLIENT CACHING` command is only applied to the next command.
+Again, the behavior change enforced by the `CLIENT CACHING` command is only applied to the next command.
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): `OK` if the argument was valid. An error is returned if the protocol is not 3, 
-or the argument does not match the current tracking mode for the client, for example if `yes` is specified when the mode is not `OFF OPTIN`, or `no` is specified when the mode is not `ON OPTOUT`.
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): `OK` if the argument is valid.
+An error is returned if RESP3 is not enabled, or the argument does not match the current tracking mode for the client.
+For example, if `YES` is specified when the mode is not `OFF OPTIN`, or `NO` is specified when the mode is not `ON OPTOUT`.
 
 ## Examples
 
-
 ```shell
-# set RESP3, caching command requires RESP3
+# Set RESP3, which is required by client-side caching.
 dragonfly> HELLO 3
+
 dragonfly> CLIENT TRACKING ON OPTOUT
 OK
 dragonfly> SET user_count 100
 OK
-# the next command will not be cached
+
+# The next command will not be cached.
 dragonfly> CLIENT CACHING NO
 OK
 dragonfly> GET user_count
 "100"
+
+# Change client tracking mode.
 dragonfly> CLIENT TRACKING OFF OPTIN
 OK
-# caching only for the next command
+
+# The next command will be cached.
 dragonfly> CLIENT CACHING YES
 OK
 dragonfly> GET user_count

--- a/docs/command-reference/server-management/client-caching.md
+++ b/docs/command-reference/server-management/client-caching.md
@@ -25,7 +25,7 @@ so that keys in read-only commands are not automatically remembered by the serve
 
 - When the client is in `OPTIN` mode, the standard behavior is to not track keys.
   The client can force tracking of the keys used in the next command by calling `CLIENT CACHING YES` before the command.
-- Similarly, when the client is in `ON OPTOUT` mode, the standard behavior is to track keys.
+- Similarly, when the client is in `OPTOUT` mode, the standard behavior is to track keys.
   This behavior can be overridden for keys used in the next command by calling `CLIENT CACHING NO` before the command.
 
 Again, the behavior change enforced by the `CLIENT CACHING` command is only applied to the next command.

--- a/docs/command-reference/server-management/client-caching.md
+++ b/docs/command-reference/server-management/client-caching.md
@@ -1,0 +1,59 @@
+---
+description:  Learn how to use Redis CLIENT CACHING command to control server-assisted client side caching for the connection.
+---
+
+import PageTitle from '@site/src/components/PageTitle';
+
+# CLIENT CACHING
+
+<PageTitle title="CLIENT CACHING Command (Documentation) | Dragonfly" />
+
+## Syntax
+
+    CLIENT CACHING <YES | NO>
+
+**Time complexity:** O(1). Some options may introduce additional complexity.
+
+**ACL categories:** @slow, @connection
+
+**Important**: Only available when the [RESP3](https://github.com/redis/redis-specifications/blob/master/protocol/RESP3.md) protocol is used.
+
+The `CLIENT CACHING` command changes tracking of keys only for the next command executed by the connection. See more details about tracking in the [documentation](https://www.dragonflydb.io/docs/command-reference/server-management/client-tracking) for the tracking command.
+
+When tracking is enabled using [CLIENT TRACKING](https://www.dragonflydb.io/docs/command-reference/server-management/client-tracking), it is possible to specify `OPTIN`
+or `OPTOUT` options, so that for example keys in read only commands are not remembered by the server.
+
+When the client is in `OFF OPTIN` mode the standard behavior is to not track keys, the client can force tracking of the keys used in the next command by calling `CLIENT CACHING YES` before the command.
+
+Similarly, when the client is in `ON OPTOUT` mode, the standard behavior is to track keys. This behavior can be overridden for keys used in the next command by calling `CLIENT CACHING NO` before the command.
+
+The behavior change enforced by the `CLIENT CACHING` command is only applied to the next command.
+
+## Return
+
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): `OK` if the argument was valid. An error is returned if the protocol is not 3, 
+or the argument does not match the current tracking mode for the client, for example if `yes` is specified when the mode is not `OFF OPTIN`, or `no` is specified when the mode is not `ON OPTOUT`.
+
+## Examples
+
+
+```shell
+# set RESP3, caching command requires RESP3
+dragonfly> HELLO 3
+dragonfly> CLIENT TRACKING ON OPTOUT
+OK
+dragonfly> SET user_count 100
+OK
+# the next command will not be cached
+dragonfly> CLIENT CACHING NO
+OK
+dragonfly> GET user_count
+"100"
+dragonfly> CLIENT TRACKING OFF OPTIN
+OK
+# caching only for the next command
+dragonfly> CLIENT CACHING YES
+OK
+dragonfly> GET user_count
+"100"
+```

--- a/docs/command-reference/server-management/client.md
+++ b/docs/command-reference/server-management/client.md
@@ -18,7 +18,7 @@ This is a container command for client connection commands.
 
 Currently, the following subcommands are supported:
 
-- CLIENT CACHING
+- [CLIENT CACHING](./client-caching.md)
 - [CLIENT GETNAME](./client-getname.md)
 - [CLIENT ID](./client-id.md)
 - [CLIENT KILL](./client-kill.md)


### PR DESCRIPTION
it seems like compat doc is already updated

fixes https://github.com/dragonflydb/documentation/issues/384