### PR TITLE
chore: update FLUSHDB/FLUSHALL options

### DIFF
--- a/docs/command-reference/server-management/client-pause.md
+++ b/docs/command-reference/server-management/client-pause.md
@@ -28,4 +28,5 @@ Client pause currently supports two modes:
 * WRITE: Clients are only blocked if they attempt to execute a write command.
 
 ## Return
-Simple string reply: OK or an error if the timeout is invalid.
+
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): `OK` or an error if the timeout is invalid.

--- a/docs/command-reference/server-management/flushall.md
+++ b/docs/command-reference/server-management/flushall.md
@@ -16,13 +16,17 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **ACL categories:** @keyspace, @write, @slow, @dangerous
 
-Delete all the keys of all the existing databases, not just the currently selected one.
+Delete all the keys for all the existing databases, not just the currently selected one.
 This command never fails.
 
-`FLUSHALL` will always asynchronously flush databases. Specifying `ASYNC` or `SYNC` does not currently affect the behavior.
+## Notes
 
-Note: an asynchronous `FLUSHALL` command only deletes keys that were present at the time the command was invoked. Keys created during an asynchronous flush will be unaffected.
+- The `FLUSHALL` command always deletes keys asynchronously.
+  It only deletes keys that were present at the time the command was invoked.
+  Keys created during the deletion will be unaffected.
+- However, if the `SYNC` option is specified, the command waits for the deletion (which is still asynchronous) to finish.
+  Because of this, unlike Redis/Valkey, this command never blocks other commands.
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): OK
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): `OK`.

--- a/docs/command-reference/server-management/flushdb.md
+++ b/docs/command-reference/server-management/flushdb.md
@@ -10,7 +10,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 ## Syntax
 
-    FLUSHDB
+    FLUSHDB [ASYNC | SYNC]
 
 **Time complexity:** O(N) where N is the number of keys in the selected database
 
@@ -19,10 +19,14 @@ import PageTitle from '@site/src/components/PageTitle';
 Delete all the keys of the currently selected database.
 This command never fails.
 
-The `FLUSHDB` command always deletes keys asynchronously.
+## Notes
 
-Note: an asynchronous `FLUSHDB` command only deletes keys that were present at the time the command was invoked. Keys created during an asynchronous flush will be unaffected.
+- The `FLUSHDB` command always deletes keys asynchronously.
+  It only deletes keys that were present at the time the command was invoked.
+  Keys created during the deletion will be unaffected.
+- However, if the `SYNC` option is specified, the command waits for the deletion (which is still asynchronous) to finish.
+  Because of this, unlike Redis/Valkey, this command never blocks other commands.
 
 ## Return
 
-[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings)
+[Simple string reply](https://redis.io/docs/latest/develop/reference/protocol-spec/#simple-strings): `OK`.


### PR DESCRIPTION
@dranikpg Can you please check if the description matches the behavior you implemented (https://github.com/dragonflydb/dragonfly/pull/5821)?

- The `FLUSH*` command always deletes keys asynchronously. It only deletes keys that were present at the time the command was invoked. Keys created during the deletion will be unaffected.
- However, if the `SYNC` option is specified, the command waits for the deletion (which is still asynchronous) to finish. Because of this, unlike Redis/Valkey, this command never blocks other commands.
