### PR TITLE
docs: Add Top-K command reference, update Bloom Filter and compatibility table

### DIFF
--- a/docs/cloud/pricing.md
+++ b/docs/cloud/pricing.md
@@ -3,7 +3,7 @@ sidebar_position: 13
 ---
 
 import PageTitle from '@site/src/components/PageTitle';
-import CloudBadge from'@site/src/components/CloudBadge/CloudBadge'
+import CloudBadge from '@site/src/components/CloudBadge/CloudBadge'
 
 # Pricing
 <CloudBadge/>
@@ -13,13 +13,12 @@ import CloudBadge from'@site/src/components/CloudBadge/CloudBadge'
 
 Dragonfly Cloud applies a transparent usage-based pricing model with the following components:
 
-- [Pricing](#pricing)
-  - [Overview](#overview)
-  - [Active Data Stores](#active-data-stores)
-    - [Active Data Store Cost Calculation](#active-data-store-cost-calculation)
-    - [Active Data Store Cost Example](#active-data-store-cost-example)
-  - [Data Transfer](#data-transfer)
-  - [Backup Storage](#backup-storage)
+- [Overview](#overview)
+- [Active Data Stores](#active-data-stores)
+  - [Active Data Store Cost Calculation](#active-data-store-cost-calculation)
+  - [Active Data Store Cost Example](#active-data-store-cost-example)
+- [Data Transfer](#data-transfer)
+- [Backup Storage](#backup-storage)
 
 You can track your usage and costs under the [Account > Usage](https://dragonflydb.cloud/account/usage) tab
 in Dragonfly Cloud. The usage and cost information is updated every few hours.

--- a/docs/command-reference/bloom-filter/bf.reserve.md
+++ b/docs/command-reference/bloom-filter/bf.reserve.md
@@ -18,6 +18,8 @@ import PageTitle from '@site/src/components/PageTitle';
 Creates a new Bloom filter with an initial capacity of at least `capacity`
 and a false positive rate `false_positive_rate` that should be a double between `0` and `0.5`.
 
+Note: The `EXPANSION` and `NONSCALING` options available in Redis are not currently supported.
+
 ## Return
 
 [Simple string reply](https://valkey.io/topics/protocol/#simple-strings): `OK` if the Bloom filter was created successfully.

--- a/docs/command-reference/compatibility.md
+++ b/docs/command-reference/compatibility.md
@@ -313,6 +313,8 @@ sidebar_position: 0
 |                                              | <span class="command">BF.SCANDUMP</span>                   | <span class="support unsupported">Unsupported</span>     |
 |                                              | <span class="command">BF.LOADCHUNK</span>                  | <span class="support unsupported">Unsupported</span>     |
 |                                              | <span class="command">BF.INFO</span>                       | <span class="support unsupported">Unsupported</span>     |
+|                                              | <span class="command">BF.CARD</span>                       | <span class="support unsupported">Unsupported</span>     |
+|                                              | <span class="command">BF.DEBUG</span>                      | <span class="support unsupported">Unsupported</span>     |
 | <span class="family">Cuckoo Filter</span>    | <span class="command">TBD</span>                           | <span class="support unsupported">Unsupported</span>     |
 | <span class="family">Count-Min Sketch</span> | <span class="command">CMS.INCRBY</span>                    | <span class="support supported">Fully supported</span>   |
 |                                              | <span class="command">CMS.INFO</span>                      | <span class="support supported">Fully supported</span>   |
@@ -361,7 +363,13 @@ sidebar_position: 0
 | <span class="family">Auto Suggest</span>     | <span class="command">TBD</span>                           | <span class="support unsupported">Unsupported</span>     |
 | <span class="family">T-Digest</span>         | <span class="command">TBD</span>                           | <span class="support unsupported">Unsupported</span>     |
 | <span class="family">Time Series</span>      | <span class="command">TBD</span>                           | <span class="support unsupported">Unsupported</span>     |
-| <span class="family">Top-K</span>            | <span class="command">TBD</span>                           | <span class="support unsupported">Unsupported</span>     |
+| <span class="family">Top-K</span>            | <span class="command">TOPK.RESERVE</span>                  | <span class="support supported">Fully supported</span>   |
+|                                              | <span class="command">TOPK.ADD</span>                      | <span class="support supported">Fully supported</span>   |
+|                                              | <span class="command">TOPK.INCRBY</span>                   | <span class="support supported">Fully supported</span>   |
+|                                              | <span class="command">TOPK.QUERY</span>                    | <span class="support supported">Fully supported</span>   |
+|                                              | <span class="command">TOPK.COUNT</span>                    | <span class="support supported">Fully supported</span>   |
+|                                              | <span class="command">TOPK.LIST</span>                     | <span class="support supported">Fully supported</span>   |
+|                                              | <span class="command">TOPK.INFO</span>                     | <span class="support supported">Fully supported</span>   |
 | <span class="family">CF</span>               | <span class="command">CF.ADD</span>                        | <span class="support unsupported">Unsupported</span>     |
 |                                              | <span class="command">CF.ADDNX</span>                      | <span class="support unsupported">Unsupported</span>     |
 |                                              | <span class="command">CF.COUNT</span>                      | <span class="support unsupported">Unsupported</span>     |

--- a/docs/command-reference/top-k/_category_.yml
+++ b/docs/command-reference/top-k/_category_.yml
@@ -1,0 +1,4 @@
+position: 1
+label: Top-K
+link:
+  type: generated-index

--- a/docs/command-reference/top-k/topk.add.md
+++ b/docs/command-reference/top-k/topk.add.md
@@ -1,0 +1,49 @@
+---
+description: Learn how to use the TOPK.ADD command to add items to a Top-K data structure in Dragonfly.
+---
+
+import PageTitle from '@site/src/components/PageTitle';
+
+# TOPK.ADD
+
+<PageTitle title="Redis TOPK.ADD Command (Documentation) | Dragonfly" />
+
+## Syntax
+
+    TOPK.ADD key item [item ...]
+
+**Time complexity:** O(n * depth) where n is the number of items
+
+**ACL categories:** @topk
+
+Adds one or more items to the Top-K data structure stored at `key`.
+The `key` must already exist (created via [`TOPK.RESERVE`](./topk.reserve.md)); otherwise, an error is returned.
+If an added item displaces an existing item from the top-k list, the displaced item is returned.
+
+## Return
+
+[Array reply](https://valkey.io/topics/protocol/#arrays): An array with one entry per item.
+Each entry is either:
+
+- A bulk string with the name of the item that was displaced from the top-k list.
+- `nil` if no item was displaced.
+
+## Examples
+
+```shell
+dragonfly> TOPK.RESERVE topk 2
+OK
+
+dragonfly> TOPK.ADD topk foo bar baz
+1) (nil)
+2) (nil)
+3) foo
+
+dragonfly> TOPK.LIST topk
+1) baz
+2) bar
+```
+
+## See also
+
+[`TOPK.RESERVE`](./topk.reserve.md) | [`TOPK.INCRBY`](./topk.incrby.md) | [`TOPK.QUERY`](./topk.query.md) | [`TOPK.LIST`](./topk.list.md)

--- a/docs/command-reference/top-k/topk.count.md
+++ b/docs/command-reference/top-k/topk.count.md
@@ -12,7 +12,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
     TOPK.COUNT key item [item ...]
 
-**Time complexity:** O(n * depth) where n is the number of items and depth is the number of hash function rows
+**Time complexity:** O(n) where n is the number of items
 
 **ACL categories:** @topk
 

--- a/docs/command-reference/top-k/topk.count.md
+++ b/docs/command-reference/top-k/topk.count.md
@@ -1,0 +1,50 @@
+---
+description: Learn how to use the TOPK.COUNT command to get estimated counts of items in a Top-K data structure in Dragonfly.
+---
+
+import PageTitle from '@site/src/components/PageTitle';
+
+# TOPK.COUNT
+
+<PageTitle title="Redis TOPK.COUNT Command (Documentation) | Dragonfly" />
+
+## Syntax
+
+    TOPK.COUNT key item [item ...]
+
+**Time complexity:** O(n * depth) where n is the number of items and depth is the number of hash function rows
+
+**ACL categories:** @topk
+
+Returns the estimated count of one or more items in the Top-K data structure stored at `key`.
+The `key` must already exist (created via [`TOPK.RESERVE`](./topk.reserve.md)); otherwise, an error is returned.
+The returned counts are estimates and may differ from the true counts due to the probabilistic nature of the underlying Count-Min Sketch.
+An item can have a non-zero estimated count even if it is not currently in the top-k list (as reported by [`TOPK.QUERY`](./topk.query.md)).
+
+## Return
+
+[Array reply](https://valkey.io/topics/protocol/#arrays): An array of integers, one per item, representing the estimated count of each queried item.
+
+## Examples
+
+```shell
+dragonfly> TOPK.RESERVE topk 3
+OK
+
+dragonfly> TOPK.ADD topk foo foo foo bar bar baz
+1) (nil)
+2) (nil)
+3) (nil)
+4) (nil)
+5) (nil)
+6) (nil)
+
+dragonfly> TOPK.COUNT topk foo bar baz
+1) (integer) 3
+2) (integer) 2
+3) (integer) 1
+```
+
+## See also
+
+[`TOPK.RESERVE`](./topk.reserve.md) | [`TOPK.QUERY`](./topk.query.md) | [`TOPK.LIST`](./topk.list.md) | [`TOPK.INFO`](./topk.info.md)

--- a/docs/command-reference/top-k/topk.incrby.md
+++ b/docs/command-reference/top-k/topk.incrby.md
@@ -1,0 +1,52 @@
+---
+description: Learn how to use the TOPK.INCRBY command to increment item counts in a Top-K data structure in Dragonfly.
+---
+
+import PageTitle from '@site/src/components/PageTitle';
+
+# TOPK.INCRBY
+
+<PageTitle title="Redis TOPK.INCRBY Command (Documentation) | Dragonfly" />
+
+## Syntax
+
+    TOPK.INCRBY key item increment [item increment ...]
+
+**Time complexity:** O(n * depth) where n is the number of items
+
+**ACL categories:** @topk
+
+Increments the count of one or more items in the Top-K data structure stored at `key` by the given `increment` values.
+The `key` must already exist (created via [`TOPK.RESERVE`](./topk.reserve.md)); otherwise, an error is returned.
+The `increment` value must be a positive integer between `1` and `100000`.
+If an item displaces an existing item from the top-k list, the displaced item is returned.
+
+## Return
+
+[Array reply](https://valkey.io/topics/protocol/#arrays): An array with one entry per item.
+Each entry is either:
+
+- A bulk string with the name of the item that was displaced from the top-k list.
+- `nil` if no item was displaced.
+
+## Examples
+
+```shell
+dragonfly> TOPK.RESERVE topk 2
+OK
+
+dragonfly> TOPK.INCRBY topk foo 3 bar 5 baz 10
+1) (nil)
+2) (nil)
+3) foo
+
+dragonfly> TOPK.LIST topk WITHCOUNT
+1) baz
+2) (integer) 10
+3) bar
+4) (integer) 5
+```
+
+## See also
+
+[`TOPK.RESERVE`](./topk.reserve.md) | [`TOPK.ADD`](./topk.add.md) | [`TOPK.COUNT`](./topk.count.md) | [`TOPK.LIST`](./topk.list.md)

--- a/docs/command-reference/top-k/topk.info.md
+++ b/docs/command-reference/top-k/topk.info.md
@@ -1,0 +1,50 @@
+---
+description: Learn how to use the TOPK.INFO command to retrieve information about a Top-K data structure in Dragonfly.
+---
+
+import PageTitle from '@site/src/components/PageTitle';
+
+# TOPK.INFO
+
+<PageTitle title="Redis TOPK.INFO Command (Documentation) | Dragonfly" />
+
+## Syntax
+
+    TOPK.INFO key
+
+**Time complexity:** O(1)
+
+**ACL categories:** @topk
+
+Returns metadata about the Top-K data structure stored at `key`, including its configuration parameters.
+The `key` must already exist (created via [`TOPK.RESERVE`](./topk.reserve.md)); otherwise, an error is returned.
+
+## Return
+
+[Array reply](https://valkey.io/topics/protocol/#arrays): A flat array of field-value pairs with the following fields:
+
+- `k`: The number of top items tracked.
+- `width`: The number of counters per hash function row.
+- `depth`: The number of hash function rows.
+- `decay`: The probability decay factor.
+
+## Examples
+
+```shell
+dragonfly> TOPK.RESERVE topk 5 20 7 0.9
+OK
+
+dragonfly> TOPK.INFO topk
+1) k
+2) (integer) 5
+3) width
+4) (integer) 20
+5) depth
+6) (integer) 7
+7) decay
+8) "0.9"
+```
+
+## See also
+
+[`TOPK.RESERVE`](./topk.reserve.md) | [`TOPK.LIST`](./topk.list.md) | [`TOPK.COUNT`](./topk.count.md)

--- a/docs/command-reference/top-k/topk.list.md
+++ b/docs/command-reference/top-k/topk.list.md
@@ -1,0 +1,62 @@
+---
+description: Learn how to use the TOPK.LIST command to list all items in a Top-K data structure in Dragonfly.
+---
+
+import PageTitle from '@site/src/components/PageTitle';
+
+# TOPK.LIST
+
+<PageTitle title="Redis TOPK.LIST Command (Documentation) | Dragonfly" />
+
+## Syntax
+
+    TOPK.LIST key [WITHCOUNT]
+
+**Time complexity:** O(k log k) where k is the number of top items tracked
+
+**ACL categories:** @topk
+
+Returns all items currently tracked in the Top-K data structure stored at `key`, sorted by estimated count in descending order.
+The `key` must already exist (created via [`TOPK.RESERVE`](./topk.reserve.md)); otherwise, an error is returned.
+If no items have been added yet, an empty array is returned.
+If the optional `WITHCOUNT` flag is specified, the estimated count of each item is also returned.
+
+## Return
+
+Without `WITHCOUNT`:
+[Array reply](https://valkey.io/topics/protocol/#arrays): An array of bulk strings representing the items in the top-k list.
+
+With `WITHCOUNT`:
+[Array reply](https://valkey.io/topics/protocol/#arrays): A flat array of item-count pairs, where each item name is followed by its estimated count.
+
+## Examples
+
+```shell
+dragonfly> TOPK.RESERVE topk 3
+OK
+
+dragonfly> TOPK.ADD topk foo foo foo bar bar baz
+1) (nil)
+2) (nil)
+3) (nil)
+4) (nil)
+5) (nil)
+6) (nil)
+
+dragonfly> TOPK.LIST topk
+1) foo
+2) bar
+3) baz
+
+dragonfly> TOPK.LIST topk WITHCOUNT
+1) foo
+2) (integer) 3
+3) bar
+4) (integer) 2
+5) baz
+6) (integer) 1
+```
+
+## See also
+
+[`TOPK.RESERVE`](./topk.reserve.md) | [`TOPK.ADD`](./topk.add.md) | [`TOPK.QUERY`](./topk.query.md) | [`TOPK.INFO`](./topk.info.md)

--- a/docs/command-reference/top-k/topk.query.md
+++ b/docs/command-reference/top-k/topk.query.md
@@ -1,0 +1,49 @@
+---
+description: Learn how to use the TOPK.QUERY command to check if items are in the Top-K list in Dragonfly.
+---
+
+import PageTitle from '@site/src/components/PageTitle';
+
+# TOPK.QUERY
+
+<PageTitle title="Redis TOPK.QUERY Command (Documentation) | Dragonfly" />
+
+## Syntax
+
+    TOPK.QUERY key item [item ...]
+
+**Time complexity:** O(k) per queried item, or O(m * k) when querying m items at once
+
+**ACL categories:** @topk
+
+Checks whether one or more items are currently in the Top-K list stored at `key`.
+The `key` must already exist (created via [`TOPK.RESERVE`](./topk.reserve.md)); otherwise, an error is returned.
+Each item is checked via a linear scan of the top-k heap.
+
+## Return
+
+[Array reply](https://valkey.io/topics/protocol/#arrays): An array of integers, one per item:
+
+- `1` if the item is in the top-k list.
+- `0` if the item is not in the top-k list.
+
+## Examples
+
+```shell
+dragonfly> TOPK.RESERVE topk 2
+OK
+
+dragonfly> TOPK.ADD topk foo bar baz
+1) (nil)
+2) (nil)
+3) foo
+
+dragonfly> TOPK.QUERY topk foo bar baz
+1) (integer) 0
+2) (integer) 1
+3) (integer) 1
+```
+
+## See also
+
+[`TOPK.RESERVE`](./topk.reserve.md) | [`TOPK.ADD`](./topk.add.md) | [`TOPK.COUNT`](./topk.count.md) | [`TOPK.LIST`](./topk.list.md)

--- a/docs/command-reference/top-k/topk.reserve.md
+++ b/docs/command-reference/top-k/topk.reserve.md
@@ -1,0 +1,49 @@
+---
+description: Learn how to use the TOPK.RESERVE command to initialize a Top-K data structure in Dragonfly.
+---
+
+import PageTitle from '@site/src/components/PageTitle';
+
+# TOPK.RESERVE
+
+<PageTitle title="Redis TOPK.RESERVE Command (Documentation) | Dragonfly" />
+
+## Syntax
+
+    TOPK.RESERVE key topk [width depth decay]
+
+**Time complexity:** O(1)
+
+**ACL categories:** @topk
+
+Creates a new Top-K data structure at `key` that tracks the top `topk` most frequent items.
+
+- `topk`: The number of top items to track (between `1` and `100000`).
+- `width` (optional): The number of counters per hash function row (default `8`, max `1000000`).
+- `depth` (optional): The number of hash function rows (default `7`, max `100`).
+- `decay` (optional): The probability decay factor between `0` and `1` (default `0.9`).
+
+If `width`, `depth`, and `decay` are provided, all three must be specified together.
+If `key` already exists, an error (`item exists`) is returned.
+
+## Return
+
+[Simple string reply](https://valkey.io/topics/protocol/#simple-strings): `OK` if the Top-K was created successfully.
+
+An error is returned if:
+- The `key` already exists.
+- The parameters are out of the allowed ranges.
+
+## Examples
+
+```shell
+dragonfly> TOPK.RESERVE topk 3
+OK
+
+dragonfly> TOPK.RESERVE topk_custom 5 20 7 0.9
+OK
+```
+
+## See also
+
+[`TOPK.ADD`](./topk.add.md) | [`TOPK.INFO`](./topk.info.md) | [`TOPK.LIST`](./topk.list.md)

--- a/docs/command-reference/top-k/topk.reserve.md
+++ b/docs/command-reference/top-k/topk.reserve.md
@@ -23,6 +23,11 @@ Creates a new Top-K data structure at `key` that tracks the top `topk` most freq
 - `depth` (optional): The number of hash function rows (default `7`, max `100`).
 - `decay` (optional): The probability decay factor between `0` and `1` (default `0.9`).
 
+The default parameters are recommended for most use cases.
+In particular, the default `decay` value of `0.9` uses a globally shared pre-computed lookup table,
+while a custom `decay` value forces Dragonfly to allocate a separate lookup table in memory for each key.
+Using many Top-K structures with different custom `decay` values will result in higher memory consumption.
+
 If `width`, `depth`, and `decay` are provided, all three must be specified together.
 If `key` already exists, an error (`item exists`) is returned.
 

--- a/docs/integrations/bullmq.md
+++ b/docs/integrations/bullmq.md
@@ -110,7 +110,7 @@ See [Thread Balancing](#3-thread-balancing) below for more details.
 
 You should always avoid using the same hashtag for all queues.
 But sometimes, it is fine to strategically place certain queues on the same Dragonfly thread.
-See [Queue Dependencies](#4-queue-dependencies) below for more details.
+See [Queue Dependencies](#4-queue-dependencies-parent--child) below for more details.
 
 ### 3. Thread Balancing
 


### PR DESCRIPTION
- Add complete Top-K command reference documentation (all 7 commands: RESERVE, ADD, INCRBY, QUERY, COUNT, LIST, INFO) - verified against source code in `src/server/topk_family.cc`
- Update compatibility table: Top-K marked as fully supported, added missing BF.CARD and BF.DEBUG as unsupported
- Add note to BF.RESERVE about unsupported EXPANSION/NONSCALING options
- Fix broken anchor links in pricing.md and bullmq.md
- Fix missing space in import statement in pricing.md

## Details
- **Top-K**: All 7 commands documented with syntax, time complexity, return types, and examples. Each command notes that `TOPK.RESERVE` must be called first. Complexity values verified against `src/core/topk.cc` implementation.
- **Bloom Filter**: Compatibility table now lists all 11 known BF.* commands (5 supported, 6 unsupported). `bf.reserve.md` clarifies partial support scope.
- **T-Digest / TimeSeries**: Confirmed as not implemented (no source code exists) - compatibility table already correct, no changes needed.
