### PR TITLE
Use new public Grafana dashboard

### DIFF
--- a/docs/cloud/monitoring.md
+++ b/docs/cloud/monitoring.md
@@ -22,6 +22,7 @@ If you have not yet created a Dragonfly Cloud data store, please refer to the [g
 
 - To open a data store's public dashboard, click the dashboard icon (<svg style={{marginBottom: "-3px", marginLeft: "3px"}} xmlns="http://www.w3.org/2000/svg" height="24px" viewBox="0 -960 960 960" width="24px" fill="white"><path d="M120-120v-80l80-80v160h-80Zm160 0v-240l80-80v320h-80Zm160 0v-320l80 81v239h-80Zm160 0v-239l80-80v319h-80Zm160 0v-400l80-80v480h-80ZM120-327v-113l280-280 160 160 280-280v113L560-447 400-607 120-327Z"/></svg>) in the relevant data store row.  
 - A Grafana-based dashboard will open in a new tab.
+- You can also find our public Grafana dashboard [here](https://grafana.com/grafana/dashboards/25167-dragonfly-cloud/).
 
 ## Prometheus Compatible Metrics Endpoint
 

--- a/docs/managing-dragonfly/monitoring.md
+++ b/docs/managing-dragonfly/monitoring.md
@@ -6,8 +6,7 @@ sidebar_position: 5
 
 By default, Dragonfly allows HTTP access via its main TCP port (i.e, `6379`) and it exposes Prometheus compatible metrics on `:6379/metrics`.
 
-You can use our [public Grafana dashboard](https://grafana.com/grafana/dashboards/25167-dragonfly-cloud/) to monitor your Dragonfly instance.
-Also check out this complete example of setting up a [Grafana Monitoring Stack with Dragonfly](https://github.com/dragonflydb/dragonfly/tree/main/tools/local/monitoring).
+Check out this complete example of setting up a [Grafana Monitoring Stack with Dragonfly](https://github.com/dragonflydb/dragonfly/tree/main/tools/local/monitoring).
 
 ** :warning: **
 

--- a/docs/managing-dragonfly/monitoring.md
+++ b/docs/managing-dragonfly/monitoring.md
@@ -6,7 +6,8 @@ sidebar_position: 5
 
 By default, Dragonfly allows HTTP access via its main TCP port (i.e, `6379`) and it exposes Prometheus compatible metrics on `:6379/metrics`.
 
-Check out this complete example of setting up a [Grafana Monitoring Stack with Dragonfly](https://github.com/dragonflydb/dragonfly/tree/main/tools/local/monitoring).
+You can use our [public Grafana dashboard](https://grafana.com/grafana/dashboards/25167-dragonfly-cloud/) to monitor your Dragonfly instance.
+Also check out this complete example of setting up a [Grafana Monitoring Stack with Dragonfly](https://github.com/dragonflydb/dragonfly/tree/main/tools/local/monitoring).
 
 ** :warning: **
 


### PR DESCRIPTION
We now have a public Grafana dashboard that Cloud customers can import: https://grafana.com/grafana/dashboards/25167-dragonfly-cloud/