### PR TITLE
docs: add docsync tooling for automated doc synchronization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ yarn-error.log*
 
 temp-content-update.js
 temp-new-content.json
+
+tools/generated/
+__pycache__

--- a/tools/docsync/README.md
+++ b/tools/docsync/README.md
@@ -1,0 +1,315 @@
+# docsync
+
+Production scripts that keep `docs/` in sync with the running Dragonfly
+server. Each script is end-to-end: it captures ground truth from a
+Dragonfly Docker image (and, where useful, the C++ source), applies the
+smallest possible change to the docs, and reports anything it could not
+fix.
+
+## Layout
+
+```
+tools/docsync/
+├── acl_sync.py                 # update **ACL categor(y|ies):** lines
+├── flags_sync.py               # update flag defaults + add new flags
+├── docs_sync.py                # update doc pages from a tag-to-tag source diff
+├── propose_change_message.py   # write a commit/PR title+body for the diff
+├── dfly_facts.py               # helper — Docker → JSON ground truth
+└── requirements.txt
+```
+
+Generated artifacts live under `tools/generated/` and are gitignored:
+
+```
+tools/generated/
+├── facts/<tag>.json            # output of dfly_facts.py
+├── source/<tag>.json           # parsed ABSL_FLAG / enum data (flags_sync)
+├── update_plans/plan_<ts>.json     # output of docs_sync Phase 1
+├── update_plans/results_<ts>.json  # output of docs_sync Phase 2
+├── change_messages/*.md        # output of propose_change_message.py
+└── llm_debug/                  # raw LLM responses for inspection:
+                                #   *_<ts>.txt      — JSON-parse failure
+                                #   *_validation_failed_<ts>.md — validation failure
+                                #   *_rejected_<file>_<ts>.md   — structural rejection
+```
+
+## Setup
+
+```sh
+pip install -r tools/docsync/requirements.txt
+docker pull docker.dragonflydb.io/dragonflydb/dragonfly:v1.38.0
+export ANTHROPIC_API_KEY=...    # required for: flags_sync LLM polish,
+                                # docs_sync (both phases), acl_sync repair pass,
+                                # propose_change_message
+```
+
+## acl_sync.py
+
+Captures `ACL CAT` from the live server and updates the `**ACL
+categor(y|ies):**` line on every command-reference page whose H1 matches
+a server command. Two stages:
+
+1. **Mechanical pass** — minimal-diff edits:
+   - if the *set* of categories on a page already equals the server set,
+     the file is **not touched at all**;
+   - when the set differs, categories that stay keep their original
+     order, new ones are appended (alphabetically), removed ones are
+     dropped.
+
+2. **LLM repair pass** (requires `ANTHROPIC_API_KEY`) — for every page
+   that the mechanical pass could not handle (no ACL line on a page that
+   documents a real server command, multiple ACL lines, etc.) Claude is
+   given the page text, the command name, the expected categories from
+   the server, and detailed instructions:
+   - if the page is a container / navigation page (body is mostly a list
+     of subcommand pages, language like "This is a container command for
+     ..."), classify it as overview and skip — no edit;
+   - otherwise insert exactly one new line of the form `**ACL
+     categories:** @cat1, @cat2, ...` directly after `**Time
+     complexity:**` (or after the H1 + Syntax block if there is no Time
+     complexity line), mirroring the surrounding bullet/plain style.
+   The LLM output is *validated*: the patched page must contain exactly
+   one ACL line whose category set matches the server. If validation
+   fails the patch is rejected and the page stays in the FAILED list.
+
+Pages that remain in FAILED after both stages are listed at the end of
+the run with the LLM's complaint appended — they need a human to look.
+
+```sh
+python tools/docsync/acl_sync.py --tag v1.38.0
+python tools/docsync/acl_sync.py --tag v1.38.0 --dry-run
+python tools/docsync/acl_sync.py --tag v1.38.0 --no-llm        # mechanical-only
+python tools/docsync/acl_sync.py --tag v1.38.0 --filter "search/*"
+python tools/docsync/acl_sync.py --facts tools/generated/facts/v1.38.0.json
+```
+
+Exit code is non-zero if any page is reported as FAILED after both
+passes.
+
+## flags_sync.py
+
+Synchronizes `docs/managing-dragonfly/flags.md` with the server.
+Three-stage pipeline:
+
+1. **Capture facts** from two sources:
+   - Docker (`dfly_facts.py`) — authoritative defaults, types, groups, and
+     the short `--helpfull` description.
+   - C++ source (parsed inline; the script clones the Dragonfly repo to
+     `/tmp/dragonfly-docsync` and checks out the requested tag) — gives
+     the ABSL_FLAG declaration's file/line, surrounding C++ comments, and
+     for enum-typed flags the enum's value list with positional indices.
+     Cached in `tools/generated/source/<tag>.json`.
+
+2. **Mechanical pass.**
+   - **Delete** sections for flags the server no longer reports. The
+     binary is the authoritative source: if a flag isn't there the doc
+     was wrong and the section is dropped.
+   - For each remaining flag, replace the single `default: ...` line if
+     the value differs. A byte-equivalence check skips cosmetic
+     reformatting (`0` vs `0B`, `128MiB` vs `128.00MiB`, `65536` vs
+     `64.0KiB`). **Enum-typed defaults** (doc has a number, server reports
+     an uppercase enum constant, e.g. `compression_mode: 3 →
+     MULTI_ENTRY_LZ4`) are NOT mechanically rewritten: keeping the
+     integer is what the CLI accepts, and the LLM polish is responsible
+     for adding the enum-value table to the description.
+
+3. **LLM polish** (requires `ANTHROPIC_API_KEY`). Claude receives the
+   mechanically-fixed page, the full ground-truth dict, the source-facts
+   dict (with C++ comments and enum tables), the list of flags to add,
+   the list to keep-even-though-removed, and the list of enum defaults to
+   expand. It produces a polished page that:
+   - keeps existing flag descriptions verbatim where facts already match;
+   - integrates new C++ comment context only when it adds real value;
+   - writes descriptions for flags missing from the doc using the help
+     text + source comments;
+   - for enum-typed defaults, keeps the integer in `default:` and adds a
+     value table to the description body.
+   The LLM output is validated (every server flag present, defaults match
+   modulo byte equivalence, enum defaults still integers). If validation
+   fails the LLM output is discarded and the mechanical-only result stays
+   on disk. The raw response is saved under `tools/generated/llm_debug/`
+   for inspection.
+
+Upstream `glog-src/` and `abseil_cpp-src/` flags are filtered out of
+auto-add (but their defaults are still corrected if a human chose to
+document them).
+
+```sh
+python tools/docsync/flags_sync.py --tag v1.38.0
+python tools/docsync/flags_sync.py --tag v1.38.0 --dry-run
+python tools/docsync/flags_sync.py --tag v1.38.0 --no-llm        # mechanical only
+python tools/docsync/flags_sync.py --tag v1.38.0 --skip-source   # no C++ context
+python tools/docsync/flags_sync.py --tag v1.38.0 --refresh-source
+python tools/docsync/flags_sync.py --facts tools/generated/facts/v1.38.0.json
+```
+
+Flags that the doc still lists but the server no longer reports are
+**deleted** during the mechanical pass and listed in the run summary so
+the change is visible. The server is the authoritative source — if a
+flag isn't reported, documenting it would mislead users.
+
+## docs_sync.py
+
+Updates documentation pages whose content drifted between two Dragonfly
+releases. Two phases driven by one command:
+
+1. **Discover** (single LLM call). Computes the Dragonfly source diff
+   between `--before` and `--after` (commit subjects + per-file stat,
+   never the raw diff), walks every `.md` under `docs/`, and asks Claude
+   which pages plausibly need updating and why. The plan is saved to
+   `tools/generated/update_plans/plan_<ts>.json`.
+
+   An optional `--also-update FILE` adds explicit paths to the plan
+   regardless of LLM judgement (one path per line, comments with `#`
+   ignored). These are **forced overrides** — they are always processed
+   even if the LLM decided no change is needed.
+
+2. **Update** (one LLM session per file). For each file in the plan:
+   - Read the current page.
+   - Identify the topic from the H1; if it matches a real server command,
+     pull the C++ handler body from the Dragonfly checkout at `--after`
+     and the `COMMAND` / `ACL CAT` data captured by `dfly_facts.py`.
+   - Boot a Dragonfly container at `--after` (with `--cluster_mode=emulated`
+     for cluster-family commands).
+   - Pick a **sibling page** in the same directory as a *style template*
+     (the shortest sibling that has H2 sections). The LLM is told to
+     mirror the sibling's structural / formatting conventions and never
+     introduce a style that would make the page look different from its
+     siblings.
+   - Build a `diff_context` payload only for files that came from the
+     Phase-1 LLM discovery: the discovery `reason` plus the list of
+     commits between `--before` and `--after` that touched each related
+     source file. This focuses the update session on what actually
+     changed. Files added via `--also-update` get `diff_context: null` —
+     they are reviewed against the **whole** current source state, with
+     no implicit assumption about which area needs attention.
+   - Send the page + source + sibling style + `diff_context` (or null) to
+     Claude with strict rules:
+       * only assert facts the inputs support;
+       * **general-case complexity only**, no edge cases;
+       * never invent options or behaviors;
+       * preserve frontmatter / `<PageTitle>`;
+       * preserve any human-written content the source/Docker cannot
+         refute;
+       * **match the existing visual style exactly** (heading levels,
+         metadata block style, parameter / example framing, link
+         convention) — change CONTENT not FORM;
+       * **do NOT modify the `**ACL categor(y|ies):**` line** — that
+         metadata is owned by `acl_sync.py` and must stay byte-identical;
+       * **do NOT change page structure** — keep every existing section
+         in place, do not add new top-level sections, do not move or
+         append example blocks. New examples must be placed inside the
+         page's existing `## Examples` section, beside related ones;
+       * never write a bare `<placeholder>` outside a fenced code block.
+   - **Structural validation** runs first. Catches catastrophic LLM
+     failures: output shorter than 80 non-whitespace chars, output
+     shrunk to less than half of input, output that's just `...`,
+     missing frontmatter / H1 / `<PageTitle>` / `import PageTitle`,
+     dropped H2 sections, modified ACL line. On any failure the run is
+     marked `failed`, the raw LLM markdown is saved to
+     `tools/generated/llm_debug/docs_sync_rejected_<file>_<ts>.md`, and
+     the file on disk is **not touched**.
+   - **Docker verification**: the caller walks every `dragonfly>`
+     invocation in the LLM's markdown and runs it in Docker, substituting
+     whatever output the LLM wrote with the actual server output.
+     **`FLUSHALL` is issued before every ```shell``` block** so prior
+     examples never leak into the next — each block starts from a clean
+     keyspace. Within a block state persists, so a chain like `SET k 1`
+     → `GET k` works. Non-zero exits are noted but the captured stderr
+     replaces the LLM's predicted output (so a documented error case
+     shows the real error). The LLM is encouraged to extend examples
+     with setup commands at the top of a block (e.g. `RPUSH mylist a b c`
+     before `LRANGE mylist 0 -1`) when this makes the example clearer.
+   - Post-processing safety nets:
+       * MDX placeholder wrap — anything the LLM left bare in prose
+         (`<key>` → `` `<key>` ``) is escaped, while real HTML elements
+         like `<details>` / `<summary>` are recognized and left alone;
+       * **byte-identical skip** — if final markdown == input, no write;
+       * **cosmetic-only skip** — if the only diff is blank-line counts
+         or trailing whitespace, no write. Both prevent noise edits in
+         git diff.
+
+```sh
+python tools/docsync/docs_sync.py --before v1.37.0 --after v1.38.0
+python tools/docsync/docs_sync.py --before v1.37.0 --after v1.38.0 \
+    --also-update extra_pages.txt
+python tools/docsync/docs_sync.py --before v1.37.0 --after v1.38.0 \
+    --discover-only        # write the plan and stop
+python tools/docsync/docs_sync.py \
+    --update-only-from tools/generated/update_plans/plan_<ts>.json \
+    --after v1.38.0        # skip discovery, run Phase 2 against a saved plan
+python tools/docsync/docs_sync.py --before v1.37.0 --after v1.38.0 \
+    --filter "command-reference/strings/*"
+python tools/docsync/docs_sync.py --before v1.37.0 --after v1.38.0 --dry-run
+```
+
+Per-file results are written to
+`tools/generated/update_plans/results_<ts>.json`. Each entry has a
+status (`updated`, `unchanged`, `failed`, `skipped`, `missing`, `error`)
+and a `notes` list with everything the run noticed: which sibling style
+was used, whether `diff_context` was present, how many invocations were
+verified in Docker, any non-zero exits, whether MDX safety wrapped
+anything, why a write was skipped. Failed entries also point at the
+saved raw LLM output under `tools/generated/llm_debug/` so the failure
+mode can be inspected without re-running the LLM.
+
+## propose_change_message.py
+
+Reads the working-tree diff (including untracked files via
+`git ls-files --others`) and asks Claude for a conventional-commit title
+and a Markdown PR body. Writes the result to
+`tools/generated/change_messages/<timestamp>.md` and prints it.
+
+The script never runs `git commit` or `gh pr create`. It only proposes
+text — you copy it into your own commit / PR.
+
+```sh
+python tools/docsync/propose_change_message.py
+python tools/docsync/propose_change_message.py --staged
+python tools/docsync/propose_change_message.py --base origin/main
+python tools/docsync/propose_change_message.py --dump-prompt
+```
+
+## Typical workflow
+
+```sh
+# 1. Targeted, deterministic syncs (cheap, no diff range needed).
+python tools/docsync/acl_sync.py    --tag v1.38.0
+python tools/docsync/flags_sync.py  --tag v1.38.0
+
+# 2. Cross-page content sync between two releases (LLM-driven, expensive
+#    — only run when there is a real release-to-release jump to process).
+#    Start with --discover-only to review the plan, then run Phase 2.
+python tools/docsync/docs_sync.py --before v1.37.0 --after v1.38.0 --discover-only
+python tools/docsync/docs_sync.py --update-only-from \
+    tools/generated/update_plans/plan_<ts>.json --after v1.38.0
+
+# 3. Read the failure summaries each script printed and fix anything that
+#    needs human judgement (FAILED list, llm_debug/ for rejected outputs).
+
+# 4. Verify the build.
+yarn build
+
+# 5. Get a commit/PR message proposal.
+python tools/docsync/propose_change_message.py
+```
+
+## dfly_facts.py (helper)
+
+Boots `docker.dragonflydb.io/dragonflydb/dragonfly:<tag>`, captures
+`COMMAND`, `ACL CAT`, `INFO`, `CONFIG GET *` and parses
+`dragonfly --helpfull`, then writes a JSON snapshot under
+`tools/generated/facts/<tag>.json`.
+
+Both sync scripts call this on demand and reuse the cached file when
+present. It can also be run by hand:
+
+```sh
+python tools/docsync/dfly_facts.py --tag v1.38.0
+python tools/docsync/dfly_facts.py --tag v1.38.0 --skip-pull
+```
+
+The `data` portion of the output is bit-stable across runs on the same
+tag (`jq -S .data <out>.json | sha256sum` is identical between runs).
+The `meta` portion is volatile by design (timestamp, host-dependent
+runtime config).

--- a/tools/docsync/acl_sync.py
+++ b/tools/docsync/acl_sync.py
@@ -1,0 +1,459 @@
+#!/usr/bin/env python3
+"""acl_sync.py — Synchronize ACL category lines in command-reference docs.
+
+Captures ACL ground truth from a Dragonfly Docker image (via dfly_facts.py)
+and updates every command-reference page whose H1 matches a server command.
+
+Updates are minimal-diff:
+  * If the *set* of categories on a page already equals the server set, the
+    file is not touched at all.
+  * If they differ, categories that stay in both keep their original order;
+    new categories are appended (alphabetically); categories the server no
+    longer reports are dropped.
+
+At the end the script prints an explicit list of pages that could not be
+patched (no ACL line where one is required, ambiguous match, etc.) so a
+human can decide what to do next.
+
+Usage:
+    python tools/docsync/acl_sync.py --tag v1.38.0
+    python tools/docsync/acl_sync.py --tag v1.38.0 --dry-run
+    python tools/docsync/acl_sync.py --facts tools/generated/facts/v1.38.0.json
+    python tools/docsync/acl_sync.py --tag v1.38.0 --filter "search/*"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from fnmatch import fnmatch
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_DIR = REPO_ROOT / "docs" / "command-reference"
+FACTS_DIR = REPO_ROOT / "tools" / "generated" / "facts"
+DFLY_FACTS = REPO_ROOT / "tools" / "docsync" / "dfly_facts.py"
+
+H1_RE = re.compile(r"^#[ \t]+(?P<name>[^\n]+?)\s*$", re.MULTILINE)
+ACL_LINE_RE = re.compile(
+    r"^(?P<prefix>[ \t]*[\-*]?[ \t]*\*\*ACL[ \t]+categor(?:y|ies):\*\*)"
+    r"[ \t]*(?P<tail>[^\n]*?)[ \t]*$",
+    re.MULTILINE | re.IGNORECASE,
+)
+CATEGORY_RE = re.compile(r"@[A-Za-z][A-Za-z0-9_-]*")
+
+
+@dataclass
+class PageResult:
+    path: Path
+    command: str | None = None
+    status: str = ""           # updated | unchanged | overview | failed
+    reason: str = ""
+    old: list[str] = field(default_factory=list)
+    new: list[str] = field(default_factory=list)
+    via: str = "mechanical"    # "mechanical" | "llm"
+
+
+# --- Facts loading -----------------------------------------------------------
+
+def load_facts(args: argparse.Namespace) -> dict:
+    if args.facts:
+        return json.loads(args.facts.read_text(encoding="utf-8"))
+    facts_path = FACTS_DIR / f"{args.tag}.json"
+    if facts_path.exists() and not args.refresh_facts:
+        print(f"  using cached facts: {facts_path.relative_to(REPO_ROOT)}")
+        return json.loads(facts_path.read_text(encoding="utf-8"))
+    cmd = ["python3", str(DFLY_FACTS), "--tag", args.tag]
+    if args.skip_pull:
+        cmd.append("--skip-pull")
+    print("  capturing facts via dfly_facts.py...")
+    p = subprocess.run(cmd)
+    if p.returncode != 0 or not facts_path.exists():
+        raise RuntimeError("dfly_facts capture failed")
+    return json.loads(facts_path.read_text(encoding="utf-8"))
+
+
+# --- Page parsing ------------------------------------------------------------
+
+def extract_command(text: str) -> str | None:
+    """Return the canonical uppercase command name for a page, or None."""
+    m = H1_RE.search(text)
+    if not m:
+        return None
+    name = m.group("name").strip().strip("`").strip()
+    name = re.sub(r"\s+", " ", name)
+    return name.upper() or None
+
+
+def parse_acl_line(text: str) -> tuple[re.Match | None, list[str], int]:
+    """Return (first_match, ordered_categories, total_match_count)."""
+    matches = list(ACL_LINE_RE.finditer(text))
+    if not matches:
+        return None, [], 0
+    m = matches[0]
+    raw = CATEGORY_RE.findall(m.group("tail"))
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for c in raw:
+        cl = c.lower()
+        if cl not in seen:
+            ordered.append(cl)
+            seen.add(cl)
+    return m, ordered, len(matches)
+
+
+# --- Diff logic --------------------------------------------------------------
+
+def reconcile(doc: list[str], server: list[str]) -> tuple[list[str] | None, list[str], list[str]]:
+    """Compute the new category list, preserving existing order for kept items.
+
+    Returns (new_list_or_None, added, removed). `None` means the sets are
+    equal and the file should not be touched.
+    """
+    server_set = {c.lower() for c in server}
+    doc_set = set(doc)
+    if doc_set == server_set:
+        return None, [], []
+    kept = [c for c in doc if c in server_set]
+    added = sorted(c for c in server_set if c not in doc_set)
+    removed = [c for c in doc if c not in server_set]
+    return kept + added, added, removed
+
+
+def render(prefix: str, cats: list[str]) -> str:
+    return f"{prefix} {', '.join(cats)}"
+
+
+# --- LLM repair for FAILED pages --------------------------------------------
+
+LLM_REPAIR_MODEL = "claude-sonnet-4-6"
+LLM_REPAIR_MAX_TOKENS = 8000
+
+LLM_REPAIR_SYSTEM = """\
+You repair the ACL category metadata on a Dragonfly DB documentation page.
+
+You will receive the current page text, the command name, the list of ACL
+categories the live server reports for this command, and the reason the
+deterministic patcher could not handle the page (e.g. "no ACL line",
+"multiple ACL lines").
+
+Decide ONE action and output JSON only.
+
+  1. action = "skip" — when the page is *intentionally* without an ACL
+     line. This applies when the page is a container / navigation page:
+     its body is mostly a list of subcommand pages, with language like
+     "This is a container command for ...", "To see the list of available
+     commands you can call XYZ HELP", or just a bulleted list of links to
+     sibling pages. Such pages do not have a single ACL set — each
+     subcommand has its own page.
+
+  2. action = "patch" — when the page documents the command and should
+     have an ACL line. Insert exactly ONE line of the form
+
+         **ACL categories:** @cat1, @cat2, ...
+
+     Use a leading `- ` if and only if the surrounding metadata block on
+     the page already uses bullets (e.g. there is a `- **Time complexity:** ...`
+     line nearby). Otherwise use the plain form without a leading dash.
+
+     Placement rules, in priority order:
+       (a) If the page contains a `**Time complexity:**` line, put the new
+           line directly after it (with the same indentation / leading-dash
+           style as that line).
+       (b) Else, place the new line just after the H1 and the first
+           Syntax block (whether fenced ``` or 4-space indented), with one
+           blank line on each side.
+
+     Use exactly the categories given to you in the prompt. Sort them
+     alphabetically. Do NOT change anything else on the page — no
+     description rewrites, no whitespace tweaks elsewhere, no front-matter
+     edits. The diff between input and output must be additive only:
+     exactly one new line (and at most one blank line of padding around
+     it).
+
+     If the page already has multiple ACL lines, keep only the first
+     (closest to the metadata block) and remove the duplicates, replacing
+     the surviving line's category list with the server-provided
+     categories in alphabetical order.
+
+Output strictly this JSON, with no fences and no commentary:
+
+  { "action": "skip" | "patch",
+    "reason": "<one sentence explaining the decision>",
+    "patched_markdown": "<full file content if action=patch, else empty>" }
+"""
+
+
+def _build_repair_user_text(
+    page_text: str, command: str, server_cats: list[str], failure_reason: str,
+) -> str:
+    return (
+        f"=== command ===\n{command}\n\n"
+        f"=== expected ACL categories (alphabetical) ===\n"
+        f"{', '.join(sorted(server_cats))}\n\n"
+        f"=== detector finding ===\n{failure_reason}\n\n"
+        f"=== current page ===\n{page_text}\n\n"
+        f"=== task ===\n"
+        f"Decide skip/patch and produce the JSON. JSON only.\n"
+    )
+
+
+def _call_repair_llm(client, system_prompt: str, user_text: str) -> dict:
+    response = client.messages.create(
+        model=LLM_REPAIR_MODEL,
+        max_tokens=LLM_REPAIR_MAX_TOKENS,
+        system=[{"type": "text", "text": system_prompt,
+                 "cache_control": {"type": "ephemeral"}}],
+        messages=[{"role": "user", "content": user_text}],
+    )
+    text = response.content[0].text.strip()
+    if text.startswith("```"):
+        text = text.split("\n", 1)[1] if "\n" in text else text
+        text = text.rsplit("```", 1)[0]
+    return json.loads(text)
+
+
+def _validate_llm_patch(patched: str, expected_cats: set[str]) -> str | None:
+    """Return None on pass, error string on failure."""
+    m, parsed_cats, count = parse_acl_line(patched)
+    if count != 1:
+        return f"patch produced {count} ACL line(s), expected exactly 1"
+    got = set(parsed_cats)
+    if got != expected_cats:
+        missing = expected_cats - got
+        extra = got - expected_cats
+        bits = []
+        if missing:
+            bits.append(f"missing {sorted(missing)}")
+        if extra:
+            bits.append(f"extra {sorted(extra)}")
+        return f"patch had wrong categories: {'; '.join(bits)}"
+    return None
+
+
+def llm_repair_failed(
+    results: list[PageResult],
+    command_acl: dict[str, list[str]],
+    dry_run: bool,
+) -> None:
+    """In-place: try to repair every result with status='failed' via LLM.
+
+    On success the result is mutated to status='updated' or 'overview'
+    with via='llm'. On failure the original 'failed' status is kept and
+    the LLM's complaint is appended to `reason`.
+    """
+    failed = [r for r in results if r.status == "failed"]
+    if not failed:
+        return
+    if not os.getenv("ANTHROPIC_API_KEY"):
+        for r in failed:
+            r.reason += " (LLM repair skipped: ANTHROPIC_API_KEY not set)"
+        return
+    try:
+        import anthropic
+    except ImportError:
+        for r in failed:
+            r.reason += " (LLM repair skipped: anthropic SDK not installed)"
+        return
+
+    print(f"\nLLM repair pass over {len(failed)} failed page(s)...")
+    client = anthropic.Anthropic()
+    for r in failed:
+        if not r.command or r.command not in command_acl:
+            continue
+        server_cats = sorted(c.lower() for c in command_acl[r.command])
+        page_text = r.path.read_text(encoding="utf-8")
+        user_text = _build_repair_user_text(
+            page_text, r.command, server_cats, r.reason,
+        )
+        try:
+            resp = _call_repair_llm(client, LLM_REPAIR_SYSTEM, user_text)
+        except Exception as e:
+            r.reason += f" (LLM call failed: {e})"
+            continue
+        action = (resp.get("action") or "").lower()
+        llm_reason = (resp.get("reason") or "").strip()
+        if action == "skip":
+            r.status = "overview"
+            r.reason = f"LLM marked as container/overview: {llm_reason}"
+            r.via = "llm"
+            print(f"  ⊘ {r.path.relative_to(REPO_ROOT)}: skip — {llm_reason}")
+            continue
+        if action != "patch":
+            r.reason += f" (LLM returned unknown action {action!r})"
+            print(f"  ✗ {r.path.relative_to(REPO_ROOT)}: bad action {action!r}")
+            continue
+        patched = resp.get("patched_markdown") or ""
+        if not patched.strip():
+            r.reason += " (LLM said 'patch' but returned empty markdown)"
+            print(f"  ✗ {r.path.relative_to(REPO_ROOT)}: empty patch")
+            continue
+        err = _validate_llm_patch(patched, set(server_cats))
+        if err:
+            r.reason += f" (LLM patch rejected: {err})"
+            print(f"  ✗ {r.path.relative_to(REPO_ROOT)}: {err}")
+            continue
+        # Validation passed — apply.
+        r.old = []
+        r.new = server_cats
+        r.status = "updated"
+        r.via = "llm"
+        r.reason = f"LLM-inserted ACL line: {llm_reason}"
+        if not dry_run:
+            r.path.write_text(patched, encoding="utf-8")
+        print(f"  ✓ {r.path.relative_to(REPO_ROOT)}: patched with "
+              f"{', '.join(server_cats)}")
+
+
+# --- Main --------------------------------------------------------------------
+
+def discover_pages(filter_glob: str) -> list[Path]:
+    pages = sorted(DOCS_DIR.rglob("*.md"))
+    if filter_glob:
+        pages = [p for p in pages
+                 if fnmatch(str(p.relative_to(DOCS_DIR)), filter_glob)]
+    return pages
+
+
+def process_page(path: Path, command_acl: dict, dry_run: bool) -> PageResult:
+    text = path.read_text(encoding="utf-8")
+    res = PageResult(path=path)
+    cmd = extract_command(text)
+    res.command = cmd
+    if not cmd:
+        res.status = "overview"
+        res.reason = "no H1 — not a command page"
+        return res
+    if cmd not in command_acl:
+        res.status = "overview"
+        res.reason = f"H1 {cmd!r} is not a server command"
+        return res
+    server_cats = sorted(c.lower() for c in command_acl[cmd])
+    m, doc_cats, count = parse_acl_line(text)
+    if not m:
+        res.status = "failed"
+        res.reason = "page documents a real command but has no `**ACL categor(y|ies):**` line"
+        return res
+    if count > 1:
+        res.status = "failed"
+        res.reason = f"{count} ACL lines found — manual review needed"
+        return res
+    new_list, added, removed = reconcile(doc_cats, server_cats)
+    res.old = doc_cats
+    if new_list is None:
+        res.status = "unchanged"
+        res.new = doc_cats
+        return res
+    res.new = new_list
+    if not dry_run:
+        new_text = text[:m.start()] + render(m.group("prefix"), new_list) + text[m.end():]
+        path.write_text(new_text, encoding="utf-8")
+    res.status = "updated"
+    bits: list[str] = []
+    if added:
+        bits.append(f"+{','.join(added)}")
+    if removed:
+        bits.append(f"-{','.join(removed)}")
+    res.reason = " ".join(bits)
+    return res
+
+
+def report(results: list[PageResult], dry_run: bool) -> int:
+    counters = {"updated": 0, "unchanged": 0, "overview": 0, "failed": 0}
+    via_counts = {"mechanical": 0, "llm": 0}
+    overview_via_llm = 0
+    for r in results:
+        counters[r.status] += 1
+        if r.status == "updated":
+            via_counts[r.via] += 1
+        if r.status == "overview" and r.via == "llm":
+            overview_via_llm += 1
+
+    print("")
+    print(f"Pages walked:  {len(results)}")
+    print(f"  updated:     {counters['updated']}  "
+          f"(mechanical {via_counts['mechanical']}, llm {via_counts['llm']})")
+    print(f"  unchanged:   {counters['unchanged']}")
+    print(f"  not a cmd:   {counters['overview']}  "
+          f"(silently skipped — {overview_via_llm} of them recognized as "
+          f"container/overview by the LLM repair pass)")
+    print(f"  failed:      {counters['failed']}")
+
+    if counters["updated"]:
+        suffix = " (dry-run — no files written)" if dry_run else ""
+        print(f"\n=== Updated {counters['updated']} page(s){suffix} ===")
+        for r in results:
+            if r.status != "updated":
+                continue
+            rel = r.path.relative_to(REPO_ROOT)
+            tag = " [LLM]" if r.via == "llm" else ""
+            print(f"  {rel}  ({r.command}){tag}")
+            print(f"      old: {', '.join(r.old) or '(none)'}")
+            print(f"      new: {', '.join(r.new)}")
+            if r.reason:
+                print(f"      change: {r.reason}")
+
+    if overview_via_llm:
+        print(f"\n=== {overview_via_llm} page(s) classified as container/overview "
+              f"by the LLM repair pass ===")
+        for r in results:
+            if r.status == "overview" and r.via == "llm":
+                rel = r.path.relative_to(REPO_ROOT)
+                print(f"  {rel}  ({r.command})")
+                print(f"      {r.reason}")
+
+    if counters["failed"]:
+        print(f"\n=== UPDATE FAILED on {counters['failed']} page(s) — manual review needed ===")
+        for r in results:
+            if r.status != "failed":
+                continue
+            rel = r.path.relative_to(REPO_ROOT)
+            print(f"  {rel}")
+            print(f"    command: {r.command}")
+            print(f"    reason:  {r.reason}")
+        return 1
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--tag", help="Dragonfly tag (e.g. v1.38.0).")
+    g.add_argument("--facts", type=Path,
+                   help="Path to a pre-captured facts JSON.")
+    ap.add_argument("--skip-pull", action="store_true",
+                    help="Skip docker pull when capturing facts.")
+    ap.add_argument("--refresh-facts", action="store_true",
+                    help="Re-capture facts even if a cached file exists.")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Show planned changes without writing.")
+    ap.add_argument("--filter", default="",
+                    help="Glob (relative to docs/command-reference/) "
+                         "to limit which pages are processed.")
+    ap.add_argument("--no-llm", action="store_true",
+                    help="Skip the LLM repair pass for pages without an "
+                         "ACL line.")
+    args = ap.parse_args()
+
+    facts = load_facts(args)
+    command_acl = facts["data"]["command_acl"]
+    print(f"  ground truth: {len(command_acl)} commands with ACL data")
+
+    pages = discover_pages(args.filter)
+    print(f"  scanning {len(pages)} page(s) under docs/command-reference/")
+
+    results = [process_page(p, command_acl, args.dry_run) for p in pages]
+
+    if not args.no_llm and any(r.status == "failed" for r in results):
+        llm_repair_failed(results, command_acl, args.dry_run)
+
+    return report(results, args.dry_run)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/docsync/dfly_facts.py
+++ b/tools/docsync/dfly_facts.py
@@ -1,0 +1,357 @@
+#!/usr/bin/env python3
+"""dfly_facts.py — Capture runtime facts from a Dragonfly Docker image.
+
+Boots the official Dragonfly Docker image at the given tag, queries the live
+server for its registered commands, ACL categories, INFO sections and config,
+runs `dragonfly --helpfull` in a separate ephemeral container to capture flag
+defaults, then tears everything down and writes a JSON snapshot.
+
+This is the runtime oracle for DocSync v2 drift detection. Paired with
+source_index.py (static) it provides ground truth for every fact a doc page
+might claim.
+
+Usage:
+    python tools/docsync/dfly_facts.py --tag v1.38.0
+    python tools/docsync/dfly_facts.py --tag v1.38.0 \\
+        --output tools/generated/facts/v1.38.0.json
+    python tools/docsync/dfly_facts.py --tag v1.38.0 --skip-pull
+
+Output JSON shape (top level):
+    {
+      "schema_version": 1,
+      "tag": "v1.38.0",
+      "meta": {
+        "captured_at": "2026-...Z",
+        "image_digest": "sha256:...",
+        "runtime_config": { "maxmemory": "...", ... }   # volatile, host-dependent
+      },
+      "data": {
+        "commands":        { "BITCOUNT": {arity, flags, ...}, ... },
+        "acl_categories":  { "@read": ["GET","MGET",...], ... },
+        "command_acl":     { "GET": ["@read","@string","@fast"], ... },
+        "flags":           { "tiered_storage_write_depth": {default,desc,group}, ... },
+        "info_sections":   ["Server","Clients",...]
+      }
+    }
+
+`data` is bit-stable across runs on the same tag. `meta` is volatile by design
+(captured_at varies; runtime_config holds CONFIG GET output where some values
+like maxmemory are auto-detected from host memory).
+For reproducibility tests: `jq -S .data <out>.json | sha256sum` should be
+identical between two runs on the same tag.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+import redis
+
+DRAGONFLY_IMAGE = "docker.dragonflydb.io/dragonflydb/dragonfly"
+SCHEMA_VERSION = 1
+PING_TIMEOUT_S = 30
+ANSI_RE = re.compile(r"\x1b\[[\d;]*m")
+
+
+def run(cmd: list[str], check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, capture_output=True, text=True, check=check)
+
+
+# --- Docker -------------------------------------------------------------------
+
+def docker_pull(image_ref: str) -> None:
+    print(f"  Pulling {image_ref}...")
+    run(["docker", "pull", image_ref])
+
+
+def docker_image_digest(image_ref: str) -> str:
+    p = run(["docker", "inspect", "--format", "{{index .RepoDigests 0}}", image_ref], check=False)
+    out = p.stdout.strip()
+    if "@" in out:
+        return out.split("@", 1)[1]
+    return ""
+
+
+def docker_run_dragonfly(image_ref: str, name: str) -> str:
+    """Boot Dragonfly detached. Return container IP on bridge network."""
+    run(["docker", "run", "-d", "--name", name, image_ref])
+    p = run([
+        "docker", "inspect", name,
+        "--format", "{{.NetworkSettings.Networks.bridge.IPAddress}}",
+    ])
+    ip = p.stdout.strip()
+    if not ip:
+        raise RuntimeError(f"could not determine bridge IP for container {name}")
+    return ip
+
+
+def docker_rm(name: str) -> None:
+    subprocess.run(["docker", "rm", "-f", name], capture_output=True)
+
+
+def docker_helpfull(image_ref: str) -> str:
+    """Run `dragonfly --helpfull` in an ephemeral container and return raw stdout."""
+    p = subprocess.run(
+        ["docker", "run", "--rm", "--entrypoint", "dragonfly", image_ref, "--helpfull"],
+        capture_output=True, text=True,
+    )
+    return p.stdout
+
+
+# --- Connection ---------------------------------------------------------------
+
+def wait_for_ping(ip: str, port: int = 6379, timeout: float = PING_TIMEOUT_S) -> redis.Redis:
+    deadline = time.time() + timeout
+    last_err: Exception | None = None
+    while time.time() < deadline:
+        try:
+            r = redis.Redis(host=ip, port=port, socket_timeout=2, decode_responses=True)
+            if r.ping():
+                return r
+        except (redis.RedisError, OSError) as e:
+            last_err = e
+        time.sleep(0.3)
+    raise RuntimeError(f"Dragonfly never responded to PING within {timeout}s ({last_err})")
+
+
+# --- Fact capture -------------------------------------------------------------
+
+def capture_commands(r: redis.Redis) -> dict:
+    """COMMAND → {NAME: {arity, flags, first_key_pos, last_key_pos, step_count}}.
+
+    redis-py 7.x returns this already parsed as a dict.
+    Sub-commands (e.g. ACL DELUSER) are top-level keys.
+    """
+    raw = r.execute_command("COMMAND")
+    out: dict[str, dict] = {}
+    if isinstance(raw, dict):
+        for name, entry in raw.items():
+            if isinstance(entry, dict):
+                out[name.upper()] = {
+                    "arity": entry.get("arity"),
+                    "flags": sorted(entry.get("flags", []) or []),
+                    "first_key_pos": entry.get("first_key_pos"),
+                    "last_key_pos": entry.get("last_key_pos"),
+                    "step_count": entry.get("step_count"),
+                }
+    elif isinstance(raw, list):
+        # Older redis-py: list-of-lists fallback
+        for entry in raw:
+            if isinstance(entry, list) and len(entry) >= 6:
+                name = (entry[0] or "").upper()
+                out[name] = {
+                    "arity": entry[1],
+                    "flags": sorted(entry[2] or []),
+                    "first_key_pos": entry[3],
+                    "last_key_pos": entry[4],
+                    "step_count": entry[5],
+                }
+    return dict(sorted(out.items()))
+
+
+def capture_acl(r: redis.Redis) -> tuple[dict, dict]:
+    """Return (acl_categories, command_acl).
+
+    acl_categories: {"@read": ["GET","MGET",...], ...}
+    command_acl:    {"GET": ["@read","@fast","@string"], ...}  (inverted, per-command)
+    """
+    cats_raw = r.execute_command("ACL", "CAT") or []
+    cats = sorted(c.lower() for c in cats_raw if isinstance(c, str))
+    acl_categories: dict[str, list[str]] = {}
+    command_acl: dict[str, list[str]] = {}
+    for cat in cats:
+        # ACL CAT accepts the lowercase form too
+        members = r.execute_command("ACL", "CAT", cat) or []
+        members_clean = sorted(m.upper() for m in members if isinstance(m, str))
+        acl_categories[f"@{cat}"] = members_clean
+        for m in members_clean:
+            command_acl.setdefault(m, []).append(f"@{cat}")
+    for m in command_acl:
+        command_acl[m] = sorted(set(command_acl[m]))
+    return dict(sorted(acl_categories.items())), dict(sorted(command_acl.items()))
+
+
+def capture_info_sections(container_name: str) -> list[str]:
+    """Return INFO section names by shelling out to redis-cli inside the container.
+
+    redis-py 7.x auto-parses INFO into a flat dict and drops `# Section` markers,
+    so we get raw text via the bundled redis-cli instead.
+    """
+    p = run(["docker", "exec", container_name, "redis-cli", "INFO"])
+    sections = []
+    for line in p.stdout.split("\n"):
+        line = line.strip()
+        if line.startswith("# "):
+            sections.append(line[2:].strip())
+    return sorted(set(sections))
+
+
+def capture_config(r: redis.Redis) -> dict:
+    """CONFIG GET * → dict (sorted)."""
+    raw = r.execute_command("CONFIG", "GET", "*")
+    out: dict[str, str] = {}
+    if isinstance(raw, dict):
+        out = {str(k): str(v) for k, v in raw.items()}
+    elif isinstance(raw, list):
+        # Even-indexed = keys, odd = values
+        for k, v in zip(raw[0::2], raw[1::2]):
+            out[str(k)] = str(v)
+    return dict(sorted(out.items()))
+
+
+# --- --helpfull parser --------------------------------------------------------
+
+_FLAG_START_RE = re.compile(r"^\s+--([a-z][a-z0-9_]*)\s+\(")
+_FLAGS_FROM_RE = re.compile(r"^\s*Flags from\s+(.+?):\s*$")
+_FLAG_BODY_RE = re.compile(
+    r"^--(?P<name>[a-z][a-z0-9_]*)\s*"
+    r"\((?P<desc>.*?)\)\s*;?\s*"
+    r"(?:type:\s*(?P<type>\S+);?\s*)?"
+    r"default:\s*(?P<default>.*?);?\s*$",
+    re.DOTALL,
+)
+
+
+def parse_helpfull(text: str) -> dict:
+    """Parse `dragonfly --helpfull` output into {flag: {default, description, type, group}}.
+
+    Handles multi-line description blocks and ANSI color codes around filenames.
+    """
+    text = ANSI_RE.sub("", text)
+    lines = text.split("\n")
+    flags: dict[str, dict] = {}
+    current_group: str | None = None
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        m = _FLAGS_FROM_RE.match(line)
+        if m:
+            current_group = m.group(1).strip()
+            i += 1
+            continue
+        if _FLAG_START_RE.match(line):
+            block = [line.strip()]
+            i += 1
+            while i < len(lines):
+                nxt = lines[i]
+                if _FLAG_START_RE.match(nxt) or _FLAGS_FROM_RE.match(nxt):
+                    break
+                if nxt.strip() == "":
+                    # Two empty lines in a row = end of block
+                    if i + 1 < len(lines) and lines[i + 1].strip() == "":
+                        break
+                    i += 1
+                    continue
+                block.append(nxt.strip())
+                # Block typically ends on a line containing "default: ...;"
+                if re.search(r"\bdefault:\s*[^;]*;\s*$", nxt):
+                    i += 1
+                    break
+                i += 1
+            joined = " ".join(block)
+            mb = _FLAG_BODY_RE.match(joined)
+            if mb:
+                desc = re.sub(r"\s+", " ", mb.group("desc")).strip()
+                default = mb.group("default").rstrip(";").strip()
+                ftype = (mb.group("type") or "").strip().rstrip(";") or None
+                flags[mb.group("name")] = {
+                    "default": default,
+                    "description": desc,
+                    "type": ftype,
+                    "group": current_group,
+                }
+            continue
+        i += 1
+    return dict(sorted(flags.items()))
+
+
+# --- Atomic write -------------------------------------------------------------
+
+def write_atomic_json(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, indent=2, sort_keys=True, ensure_ascii=False)
+        f.write("\n")
+    os.replace(tmp, path)
+
+
+# --- Main ---------------------------------------------------------------------
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--tag", required=True, help="Dragonfly tag (e.g. v1.38.0)")
+    p.add_argument("--output", type=Path, default=None,
+                   help="Output JSON path. Default: tools/generated/facts/<tag>.json relative to repo root.")
+    p.add_argument("--skip-pull", action="store_true",
+                   help="Skip docker pull (use already-cached image).")
+    args = p.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[2]
+    output = args.output or repo_root / "tools" / "generated" / "facts" / f"{args.tag}.json"
+    image_ref = f"{DRAGONFLY_IMAGE}:{args.tag}"
+    container_name = f"dfly-facts-{args.tag.replace('.', '-')}-{os.getpid()}"
+
+    print(f"[1/5] Image {image_ref}")
+    if not args.skip_pull:
+        docker_pull(image_ref)
+    image_digest = docker_image_digest(image_ref)
+
+    print(f"[2/5] Capture --helpfull (ephemeral container)...")
+    helpfull_raw = docker_helpfull(image_ref)
+    flags = parse_helpfull(helpfull_raw)
+    print(f"  parsed {len(flags)} flags")
+
+    print(f"[3/5] Boot {container_name}...")
+    try:
+        ip = docker_run_dragonfly(image_ref, container_name)
+        print(f"  IP: {ip}")
+        r = wait_for_ping(ip)
+
+        print("[4/5] Capture runtime facts...")
+        commands = capture_commands(r)
+        print(f"  COMMAND: {len(commands)} entries")
+        acl_categories, command_acl = capture_acl(r)
+        print(f"  ACL CAT: {len(acl_categories)} categories, {len(command_acl)} command mappings")
+        info_sections = capture_info_sections(container_name)
+        print(f"  INFO sections: {info_sections}")
+        config = capture_config(r)
+        print(f"  CONFIG: {len(config)} entries")
+    finally:
+        docker_rm(container_name)
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "tag": args.tag,
+        "meta": {
+            "captured_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "image_digest": image_digest,
+            "runtime_config": config,
+        },
+        "data": {
+            "commands": commands,
+            "acl_categories": acl_categories,
+            "command_acl": command_acl,
+            "info_sections": info_sections,
+            "flags": flags,
+        },
+    }
+
+    print(f"[5/5] Write {output}")
+    write_atomic_json(output, payload)
+    print(f"  wrote {output} ({output.stat().st_size:,} bytes)")
+    print(f"\nReproducibility check:")
+    print(f"  jq -S .data {output} | sha256sum")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/docsync/docs_sync.py
+++ b/tools/docsync/docs_sync.py
@@ -1,0 +1,1343 @@
+#!/usr/bin/env python3
+"""docs_sync.py — Update doc pages based on Dragonfly source changes between tags.
+
+Two phases. The first is a single LLM call that produces a plan. The second
+runs one LLM session per file in that plan, with Docker-verified examples
+and the source code at the new tag as factual ground truth.
+
+Phase 1 — Discover:
+  * Compute the source-tree diff between <before> and <after> in the
+    Dragonfly checkout (commit subjects + per-file stat — never the raw
+    diff, which is too noisy and too big).
+  * Walk every .md under docs/ and build an index of (path, H1, first
+    descriptive paragraph).
+  * One LLM call returns a plan: which doc files need updates and why,
+    plus optional pointers to relevant source files.
+  * If --also-update <file> is given, every path in that file is force-
+    appended to the plan even if the LLM said "no change".
+  * The plan is saved to tools/generated/update_plans/<ts>.json.
+
+Phase 2 — Update each file:
+  * For each entry in the plan, read the current page.
+  * Identify the topic (H1 → command name when it matches a real server
+    command; otherwise generic page).
+  * Pull the relevant source excerpts at <after> (handler body, ABSL_FLAG
+    declarations, etc.).
+  * Boot a Dragonfly Docker container at <after>. Run every redis-cli
+    invocation already on the page and capture the actual output. New
+    examples the LLM proposes are also run in Docker before they're
+    accepted; if a proposed example errors out it is dropped.
+  * The LLM produces the updated markdown with strict rules: only facts
+    that the source or Docker confirms; general-case complexity only;
+    never invent options or behaviors.
+
+CLI:
+    python docs_sync.py --before v1.37.0 --after v1.38.0
+    python docs_sync.py --before v1.37.0 --after v1.38.0 --also-update extra.txt
+    python docs_sync.py --before v1.37.0 --after v1.38.0 --discover-only
+    python docs_sync.py --update-only-from tools/generated/update_plans/<ts>.json
+    python docs_sync.py --before v1.37.0 --after v1.38.0 --dry-run
+    python docs_sync.py --before v1.37.0 --after v1.38.0 --filter "command-reference/strings/*"
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from fnmatch import fnmatch
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS_DIR = REPO_ROOT / "docs"
+GENERATED = REPO_ROOT / "tools" / "generated"
+PLANS_DIR = GENERATED / "update_plans"
+LLM_DEBUG_DIR = GENERATED / "llm_debug"
+FACTS_DIR = GENERATED / "facts"
+DFLY_FACTS = REPO_ROOT / "tools" / "docsync" / "dfly_facts.py"
+
+DRAGONFLY_REPO_URL = "https://github.com/dragonflydb/dragonfly.git"
+DRAGONFLY_CHECKOUT = Path("/tmp/dragonfly-docsync")
+DRAGONFLY_IMAGE = "docker.dragonflydb.io/dragonflydb/dragonfly"
+
+MODEL = "claude-sonnet-4-6"
+DISCOVER_MAX_TOKENS = 16000
+UPDATE_MAX_TOKENS = 24000
+PING_TIMEOUT_S = 30
+
+
+# --- Helpers ----------------------------------------------------------------
+
+def run(cmd: list[str], cwd: Path | None = None,
+        check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=check)
+
+
+def ensure_dragonfly_checkout(tag: str, refresh: bool = False) -> Path:
+    if not (DRAGONFLY_CHECKOUT / ".git").exists():
+        DRAGONFLY_CHECKOUT.parent.mkdir(parents=True, exist_ok=True)
+        print(f"  cloning Dragonfly source to {DRAGONFLY_CHECKOUT}...")
+        run(["git", "clone", "--quiet", DRAGONFLY_REPO_URL, str(DRAGONFLY_CHECKOUT)])
+    if refresh:
+        run(["git", "fetch", "--tags", "--quiet"], cwd=DRAGONFLY_CHECKOUT, check=False)
+    run(["git", "checkout", "--quiet", tag], cwd=DRAGONFLY_CHECKOUT, check=False)
+    return DRAGONFLY_CHECKOUT
+
+
+# --- Markdown index ----------------------------------------------------------
+
+H1_RE = re.compile(r"^#[ \t]+(?P<text>[^\n]+?)\s*$", re.MULTILINE)
+FRONTMATTER_RE = re.compile(r"\A---\n(.*?)\n---\n", re.DOTALL)
+
+
+def extract_h1(text: str) -> str | None:
+    m = H1_RE.search(text)
+    if not m:
+        return None
+    return m.group("text").strip().strip("`").strip()
+
+
+def extract_first_paragraph(text: str, max_chars: int = 400) -> str:
+    """Return the first descriptive paragraph after H1, stripped of import
+    statements and component tags. Truncated to max_chars."""
+    body = FRONTMATTER_RE.sub("", text)
+    h1m = H1_RE.search(body)
+    if h1m:
+        body = body[h1m.end():]
+    cleaned: list[str] = []
+    for line in body.split("\n"):
+        s = line.strip()
+        if not s:
+            if cleaned:
+                break
+            continue
+        if s.startswith(("import ", "<", "##", "###", "```", "**Time complexity:**",
+                         "**ACL")):
+            continue
+        cleaned.append(s)
+        if sum(len(x) for x in cleaned) > max_chars:
+            break
+    para = " ".join(cleaned).strip()
+    if len(para) > max_chars:
+        para = para[:max_chars].rstrip() + "…"
+    return para
+
+
+def collect_md_index(filter_glob: str = "") -> list[dict]:
+    out: list[dict] = []
+    for f in sorted(DOCS_DIR.rglob("*.md")):
+        rel = str(f.relative_to(REPO_ROOT))
+        if filter_glob and not fnmatch(rel, filter_glob) \
+                and not fnmatch(str(f.relative_to(DOCS_DIR)), filter_glob):
+            continue
+        try:
+            text = f.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        out.append({
+            "path": rel,
+            "h1": extract_h1(text),
+            "summary": extract_first_paragraph(text),
+        })
+    return out
+
+
+# --- Source diff summary -----------------------------------------------------
+
+def collect_source_diff_summary(before: str, after: str) -> dict:
+    src = ensure_dragonfly_checkout(after)
+    # Make sure we have <before> too — fetch all tags.
+    run(["git", "fetch", "--tags", "--quiet"], cwd=src, check=False)
+    log = run(["git", "log", "--no-merges", "--pretty=%h %s",
+               f"{before}..{after}"], cwd=src, check=False).stdout
+    stat = run(["git", "diff", "--stat", f"{before}..{after}"],
+               cwd=src, check=False).stdout
+    name_only = run(["git", "diff", "--name-only", f"{before}..{after}"],
+                    cwd=src, check=False).stdout
+    return {
+        "before": before,
+        "after": after,
+        "commits": [l for l in log.splitlines() if l.strip()],
+        "stat": stat,
+        "files_changed": [l for l in name_only.splitlines() if l.strip()],
+    }
+
+
+def commits_touching_file(before: str, after: str, src_file: str) -> list[str]:
+    """Return commits between before and after that touched src_file."""
+    p = run(
+        ["git", "log", "--no-merges", "--pretty=%h %s",
+         f"{before}..{after}", "--", src_file],
+        cwd=DRAGONFLY_CHECKOUT, check=False,
+    )
+    return [l for l in p.stdout.splitlines() if l.strip()]
+
+
+def build_diff_context(before: str, after: str, related_files: list[str],
+                       reason: str) -> dict:
+    """Compose the per-file diff_context to pass to the update LLM session."""
+    commits_per_file = []
+    for f in related_files:
+        commits = commits_touching_file(before, after, f)
+        if commits:
+            commits_per_file.append({"file": f, "commits": commits})
+    return {
+        "before": before,
+        "after": after,
+        "discovery_reason": reason,
+        "commits_per_file": commits_per_file,
+    }
+
+
+# --- LLM helpers -------------------------------------------------------------
+
+def _extract_json_object(text: str) -> dict | None:
+    text = text.strip()
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+    fence = re.search(r"```(?:json|JSON)?\s*\n(.*?)\n```", text, re.DOTALL)
+    if fence:
+        try:
+            return json.loads(fence.group(1).strip())
+        except json.JSONDecodeError:
+            pass
+    depth = 0
+    in_str: str | None = None
+    start = -1
+    i = 0
+    while i < len(text):
+        c = text[i]
+        if in_str:
+            if c == "\\" and i + 1 < len(text):
+                i += 2
+                continue
+            if c == in_str:
+                in_str = None
+        elif c == '"':
+            in_str = c
+        elif c == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0 and start != -1:
+                try:
+                    return json.loads(text[start:i + 1])
+                except json.JSONDecodeError:
+                    start = -1
+        i += 1
+    return None
+
+
+def call_llm_streaming(client, system_prompt: str, user_text: str,
+                       max_tokens: int, label: str) -> tuple[dict, dict]:
+    text_parts: list[str] = []
+    chars = 0
+    print(f"  streaming response", end="", flush=True)
+    with client.messages.stream(
+        model=MODEL,
+        max_tokens=max_tokens,
+        system=[{"type": "text", "text": system_prompt,
+                 "cache_control": {"type": "ephemeral"}}],
+        messages=[{"role": "user", "content": user_text}],
+    ) as stream:
+        for chunk in stream.text_stream:
+            text_parts.append(chunk)
+            chars += len(chunk)
+            if chars % 4000 < len(chunk):
+                print(".", end="", flush=True)
+        response = stream.get_final_message()
+    print(f" done ({chars} chars)")
+    text = "".join(text_parts).strip()
+    parsed = _extract_json_object(text)
+    if parsed is None:
+        LLM_DEBUG_DIR.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        debug = LLM_DEBUG_DIR / f"docs_sync_{label}_{ts}.txt"
+        debug.write_text(text, encoding="utf-8")
+        raise RuntimeError(
+            f"LLM response did not contain a parseable JSON object; "
+            f"raw saved to {debug.relative_to(REPO_ROOT)}"
+        )
+    usage = {
+        "input_tokens": response.usage.input_tokens,
+        "output_tokens": response.usage.output_tokens,
+        "stop_reason": response.stop_reason,
+    }
+    return parsed, usage
+
+
+# --- Phase 1: Discover -------------------------------------------------------
+
+DISCOVER_SYSTEM = """\
+You triage which documentation pages need updating after a Dragonfly DB
+release. You receive a summary of source-code changes between two tags
+(commit subjects + per-file stat) and an index of every Markdown page
+under docs/.
+
+Decide, for each page, whether the source changes plausibly require an
+update. Be conservative: only flag a page when there is a credible link
+between a commit / changed file and the page's topic. Do not invent
+links. Pages whose topic is unrelated to the source changes (e.g. a
+generic installation guide unaffected by a server change) should not be
+flagged.
+
+Return JSON only — no prose, no markdown fences, no preamble:
+
+  {
+    "files_to_update": [
+      { "path":  "docs/...md",
+        "reason": "<one sentence stating which commit / file motivates this>",
+        "related_source_files": ["src/server/...cc", ...] },
+      ...
+    ],
+    "no_update_needed_summary": "<one short sentence about the pages that
+                                  were not flagged>"
+  }
+
+The output JSON's first character must be `{` and the last must be `}`.
+"""
+
+
+def build_discover_prompt(diff: dict, md_index: list[dict]) -> str:
+    parts = [
+        f"=== source diff summary {diff['before']}..{diff['after']} ===",
+        f"commits ({len(diff['commits'])}):",
+        "\n".join(diff["commits"][:300]),
+        ("..." if len(diff["commits"]) > 300 else ""),
+        "",
+        "files_changed (top of diff --stat):",
+        "\n".join(diff["stat"].splitlines()[:200]),
+        ("..." if len(diff["stat"].splitlines()) > 200 else ""),
+        "",
+        f"=== docs index ({len(md_index)} markdown files) ===",
+        json.dumps(md_index, indent=2, ensure_ascii=False),
+        "",
+        "=== task ===",
+        "Produce the JSON {files_to_update, no_update_needed_summary}.",
+        "JSON only.",
+    ]
+    return "\n".join(p for p in parts if p)
+
+
+def discover_phase(before: str, after: str, also_update: list[str],
+                   md_filter: str) -> dict:
+    print(f"\n[Phase 1] Discover updates needed between {before} and {after}")
+    diff = collect_source_diff_summary(before, after)
+    print(f"  source diff: {len(diff['commits'])} commits, "
+          f"{len(diff['files_changed'])} files changed")
+    md_index = collect_md_index(md_filter)
+    print(f"  docs index:  {len(md_index)} markdown file(s)")
+
+    plan: dict = {
+        "before": before,
+        "after": after,
+        "generated_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "files_to_update": [],
+        "llm_summary": "",
+        "manual_overrides": [],
+    }
+
+    if not os.getenv("ANTHROPIC_API_KEY"):
+        print("  WARNING: ANTHROPIC_API_KEY not set — skipping LLM analysis. "
+              "Plan will only contain --also-update entries (if any).")
+    else:
+        try:
+            import anthropic
+        except ImportError:
+            print("  WARNING: anthropic SDK missing — LLM analysis skipped.")
+        else:
+            client = anthropic.Anthropic()
+            user_text = build_discover_prompt(diff, md_index)
+            print("  asking Claude to triage...")
+            parsed, usage = call_llm_streaming(
+                client, DISCOVER_SYSTEM, user_text,
+                DISCOVER_MAX_TOKENS, "discover",
+            )
+            print(f"  tokens: in={usage['input_tokens']} "
+                  f"out={usage['output_tokens']}")
+            plan["files_to_update"] = parsed.get("files_to_update", []) or []
+            plan["llm_summary"] = parsed.get("no_update_needed_summary", "") or ""
+
+    # Attach diff_context for every LLM-discovered entry. Files added via
+    # --also-update get diff_context = null so the update session does NOT
+    # narrow its focus based on the source diff.
+    for entry in plan["files_to_update"]:
+        related = entry.get("related_source_files", []) or []
+        reason = entry.get("reason", "")
+        entry["diff_context"] = build_diff_context(before, after, related, reason)
+
+    if also_update:
+        existing_paths = {e["path"] for e in plan["files_to_update"]}
+        for path in also_update:
+            plan["manual_overrides"].append(path)
+            if path in existing_paths:
+                # The path was already in the LLM-discovered list; keep the
+                # diff_context that we built for it. Do NOT downgrade it to
+                # null, because the diff context is genuine evidence.
+                continue
+            plan["files_to_update"].append({
+                "path": path,
+                "reason": "manual override (--also-update)",
+                "related_source_files": [],
+                "diff_context": None,
+            })
+
+    PLANS_DIR.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    plan_path = PLANS_DIR / f"plan_{ts}.json"
+    plan_path.write_text(
+        json.dumps(plan, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    plan["_plan_path"] = str(plan_path.relative_to(REPO_ROOT))
+
+    print(f"\n  plan saved: {plan['_plan_path']}")
+    print(f"  files to update: {len(plan['files_to_update'])}")
+    if plan["manual_overrides"]:
+        print(f"  manual overrides: {len(plan['manual_overrides'])}")
+    return plan
+
+
+# --- Source extraction (for Phase 2) ----------------------------------------
+
+def _find_balanced(text: str, open_pos: int) -> int:
+    open_c = text[open_pos]
+    close_c = {"{": "}", "(": ")"}.get(open_c)
+    if not close_c:
+        return -1
+    depth = 0
+    in_str: str | None = None
+    i = open_pos
+    while i < len(text):
+        c = text[i]
+        if in_str:
+            if c == "\\" and i + 1 < len(text):
+                i += 2
+                continue
+            if c == in_str:
+                in_str = None
+        elif c == '"':
+            in_str = c
+        elif c == open_c:
+            depth += 1
+        elif c == close_c:
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return -1
+
+
+def find_command_handler_source(src_root: Path, command: str) -> dict | None:
+    """Locate the C++ handler for `command`. Returns
+    {file, registration_line, handler_function, handler_body} or None."""
+    bare = command.split()[0].upper()
+    grep_pat = rf'CI{{[^}}]*"{re.escape(bare)}"'
+    p = run(["grep", "-rln", "-E", grep_pat, str(src_root / "src"),
+             "--include=*.cc", "--include=*.h"], check=False)
+    files = [Path(line) for line in p.stdout.splitlines() if line]
+    for f in files:
+        try:
+            text = f.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        # find registration: CI{ "BARE", ... }.HFUNC(<func>) — broadly
+        reg_re = re.compile(
+            rf'CI{{[^}}]*"{re.escape(bare)}"[^}}]*}}\s*\.\s*'
+            r'(?:HFUNC|MFUNC|HFUNC2|SetHandler)\s*\(\s*(?P<fn>[A-Za-z_]\w*)',
+            re.DOTALL,
+        )
+        rm = reg_re.search(text)
+        if not rm:
+            continue
+        fn_name = rm.group("fn")
+        candidates = [f"Cmd{fn_name}", fn_name]
+        for cand in candidates:
+            body_re = re.compile(
+                r"(?:^|\n)\s*(?:[A-Za-z_][\w<>:&*]*\s+)+"
+                r"(?:[A-Za-z_]\w*::)?" + re.escape(cand)
+                + r"\s*\([^{};]*?\)\s*(?:const|noexcept)?\s*\{",
+                re.DOTALL,
+            )
+            bm = body_re.search(text)
+            if not bm:
+                continue
+            open_brace = bm.end() - 1
+            close_brace = _find_balanced(text, open_brace)
+            if close_brace > open_brace:
+                body = text[bm.start():close_brace + 1]
+                if len(body) > 8000:
+                    body = body[:8000] + "\n// ... (truncated)\n}"
+                return {
+                    "file": str(f.relative_to(src_root)),
+                    "registration_line": text[:rm.start()].count("\n") + 1,
+                    "handler_function": cand,
+                    "handler_body": body,
+                }
+    return None
+
+
+# --- MDX safety net (forbid raw <placeholder> JSX-confusable angle brackets) -
+
+# Common HTML elements that Docusaurus / MDX 3 accept as-is when the page
+# uses them deliberately (e.g. `<details><summary>...</summary></details>`
+# blocks, inline `<code>...</code>`, `<b>`, etc.). We only consider these
+# "safe" — every OTHER lowercase `<tag>` is treated as a placeholder that
+# would crash the build.
+KNOWN_HTML_TAGS = frozenset({
+    "a", "abbr", "address", "article", "aside", "b", "blockquote", "br",
+    "button", "cite", "code", "col", "colgroup", "dd", "del", "details",
+    "div", "dl", "dt", "em", "figcaption", "figure", "footer", "h1", "h2",
+    "h3", "h4", "h5", "h6", "header", "hr", "i", "img", "input", "ins",
+    "kbd", "label", "li", "main", "mark", "nav", "noscript", "ol", "p",
+    "pre", "s", "samp", "section", "small", "span", "strong", "sub",
+    "summary", "sup", "table", "tbody", "td", "tfoot", "th", "thead",
+    "time", "tr", "u", "ul", "var", "wbr",
+})
+
+_FENCE_RE = re.compile(r"^\s*(```|~~~)")
+_INDENTED_RE = re.compile(r"^( {4,}|\t)")
+_PLACEHOLDER_RE = re.compile(r"<([a-z][a-z0-9_:.\-]*)>")
+_INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
+
+
+def _wrap_placeholders_in_prose(line: str) -> str:
+    """Wrap bare `<placeholder>` in inline code, preserving content already
+    inside backtick spans and leaving known HTML tags alone."""
+    def sub_outside_code(s: str) -> str:
+        return _PLACEHOLDER_RE.sub(
+            lambda m: m.group(0)
+            if m.group(1).lower() in KNOWN_HTML_TAGS
+            else f"`<{m.group(1)}>`",
+            s,
+        )
+    out: list[str] = []
+    last = 0
+    for m in _INLINE_CODE_RE.finditer(line):
+        out.append(sub_outside_code(line[last:m.start()]))
+        out.append(m.group(0))
+        last = m.end()
+    out.append(sub_outside_code(line[last:]))
+    return "".join(out)
+
+
+def fix_mdx_jsx_unsafe(text: str) -> str:
+    """Make `text` safe for MDX 3 parsing.
+
+    MDX 3 treats `<word>` as JSX even inside indented code blocks, so a
+    bare `<key>` placeholder breaks the site build. Strategy:
+      * Inside fenced ``` ... ``` blocks: leave content untouched.
+      * Inside 4-space indented blocks that contain placeholders: convert
+        the whole block to a fenced ```text``` block (safe).
+      * In prose: wrap `<word>` placeholders in inline code (`` `<word>` ``)
+        unless `word` is a known HTML element or already inside an existing
+        backtick span.
+    """
+    lines = text.splitlines()
+    out: list[str] = []
+    in_fence = False
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        if _FENCE_RE.match(line):
+            in_fence = not in_fence
+            out.append(line)
+            i += 1
+            continue
+        if not in_fence and _INDENTED_RE.match(line):
+            j = i
+            block: list[str] = []
+            while j < len(lines):
+                ln = lines[j]
+                if _FENCE_RE.match(ln):
+                    break
+                if ln.strip() == "" or _INDENTED_RE.match(ln):
+                    block.append(ln)
+                    j += 1
+                else:
+                    break
+            while block and block[-1].strip() == "":
+                block.pop()
+            if any(_PLACEHOLDER_RE.search(b) for b in block):
+                stripped = [b[4:] if b.startswith("    ") else b.lstrip("\t")
+                            for b in block]
+                out.append("```text")
+                out.extend(stripped)
+                out.append("```")
+                i = i + len(block)
+                continue
+            out.extend(block)
+            i = i + len(block)
+            continue
+        if not in_fence:
+            line = _wrap_placeholders_in_prose(line)
+        out.append(line)
+        i += 1
+    result = "\n".join(out)
+    if text.endswith("\n") and not result.endswith("\n"):
+        result += "\n"
+    return result
+
+
+# --- Docker example verification --------------------------------------------
+
+SHELL_BLOCK_RE = re.compile(
+    r"^```shell[ \t]*\n(?P<body>.*?)^```\s*$",
+    re.DOTALL | re.MULTILINE,
+)
+
+
+def extract_redis_invocations(text: str) -> list[str]:
+    """Return every `dragonfly>` line found inside ```shell blocks."""
+    invocations: list[str] = []
+    for m in SHELL_BLOCK_RE.finditer(text):
+        for line in m.group("body").splitlines():
+            line = line.rstrip()
+            if line.startswith("dragonfly> "):
+                invocations.append(line[len("dragonfly> "):].strip())
+            elif line.startswith("$ redis-cli "):
+                invocations.append(line[len("$ redis-cli "):].strip())
+    return invocations
+
+
+@dataclass
+class DockerSession:
+    container: str
+    tag: str
+
+    def exec(self, argv: list[str]) -> tuple[str, str, int]:
+        full = ["docker", "exec", self.container, "redis-cli", "--no-raw"] + argv
+        p = subprocess.run(full, capture_output=True, text=True)
+        return p.stdout.rstrip(), p.stderr.rstrip(), p.returncode
+
+
+def boot_docker(tag: str, emulated_cluster: bool = False,
+                skip_pull: bool = False) -> DockerSession:
+    image_ref = f"{DRAGONFLY_IMAGE}:{tag}"
+    if not skip_pull:
+        run(["docker", "pull", image_ref], check=False)
+    container = f"dfly-docs-sync-{tag.replace('.', '-')}-{os.getpid()}"
+    args = ["docker", "run", "-d", "--name", container, image_ref]
+    if emulated_cluster:
+        args.append("--cluster_mode=emulated")
+    run(args)
+    deadline = time.time() + PING_TIMEOUT_S
+    while time.time() < deadline:
+        p = run(["docker", "exec", container, "redis-cli", "PING"], check=False)
+        if p.returncode == 0 and "PONG" in p.stdout:
+            return DockerSession(container=container, tag=tag)
+        time.sleep(0.3)
+    subprocess.run(["docker", "rm", "-f", container], capture_output=True)
+    raise RuntimeError(f"Dragonfly {tag} did not respond to PING")
+
+
+def kill_docker(session: DockerSession) -> None:
+    subprocess.run(["docker", "rm", "-f", session.container],
+                   capture_output=True)
+
+
+def verify_invocations(session: DockerSession,
+                       invocations: list[str]) -> list[dict]:
+    """Run each invocation and capture the actual output. Returns a list of
+    {invocation, stdout, stderr, returncode}."""
+    out: list[dict] = []
+    for inv in invocations:
+        argv = inv.split()
+        stdout, stderr, rc = session.exec(argv)
+        out.append({
+            "invocation": inv,
+            "stdout": stdout,
+            "stderr": stderr,
+            "returncode": rc,
+            "ok": rc == 0,
+        })
+    return out
+
+
+def normalize_for_compare(text: str) -> list[str]:
+    """Reduce text to the sequence of its non-blank lines, with each line's
+    trailing whitespace stripped but internal whitespace preserved.
+
+    Two texts that compare equal under this normalization differ ONLY in
+    blank-line counts and/or trailing-whitespace — i.e. they are
+    semantically identical. Real edits change at least one non-blank line.
+    """
+    return [l.rstrip() for l in text.split("\n") if l.strip()]
+
+
+def validate_update_output(input_md: str, output_md: str) -> list[str]:
+    """Structural sanity check between LLM output and the input page.
+    Returns list of error strings (empty = pass).
+
+    These checks catch catastrophic LLM failures like returning `...`,
+    truncating mid-document, or losing the frontmatter / H1 / required
+    JSX imports. We do NOT call validation a soft warning — anything
+    here means we refuse to write the file.
+    """
+    errors: list[str] = []
+
+    if len(output_md.strip()) < 80:
+        errors.append(
+            f"output is catastrophically short "
+            f"({len(output_md.strip())} non-whitespace chars; "
+            f"input was {len(input_md)})"
+        )
+    elif len(output_md) < len(input_md) * 0.5:
+        errors.append(
+            f"output ({len(output_md)} chars) shrunk to less than half "
+            f"of input ({len(input_md)} chars) — likely truncation"
+        )
+
+    if re.match(r"\A\s*\.{3,}\s*\Z", output_md):
+        errors.append("output is a placeholder (`...`)")
+
+    in_fm = bool(re.match(r"\A---\n.*?\n---\n", input_md, re.DOTALL))
+    out_fm = bool(re.match(r"\A---\n.*?\n---\n", output_md, re.DOTALL))
+    if in_fm and not out_fm:
+        errors.append("frontmatter (---...---) block was lost")
+
+    if re.search(r"^# ", input_md, re.MULTILINE) \
+            and not re.search(r"^# ", output_md, re.MULTILINE):
+        errors.append("H1 header was lost")
+
+    in_h2 = len(re.findall(r"^## ", input_md, re.MULTILINE))
+    out_h2 = len(re.findall(r"^## ", output_md, re.MULTILINE))
+    if out_h2 < in_h2:
+        errors.append(
+            f"H2 section count dropped from {in_h2} to {out_h2} — "
+            f"page structure was changed"
+        )
+
+    if "<PageTitle" in input_md and "<PageTitle" not in output_md:
+        errors.append("<PageTitle ...> tag was lost")
+
+    if "import PageTitle" in input_md and "import PageTitle" not in output_md:
+        errors.append("`import PageTitle from ...` line was lost")
+
+    # ACL line: rule #4 says do not modify it. Take the input ACL line text
+    # and confirm it appears verbatim in the output.
+    in_acl = re.search(
+        r"^[ \t]*[\-*]?[ \t]*\*\*ACL[ \t]+categor(?:y|ies):\*\*[^\n]*",
+        input_md, re.MULTILINE | re.IGNORECASE,
+    )
+    if in_acl:
+        if in_acl.group(0).rstrip() not in output_md:
+            errors.append(
+                "ACL categories line was modified (rule #4 — owned by acl_sync.py)"
+            )
+
+    return errors
+
+
+def verify_and_substitute_examples(
+    text: str, session: DockerSession,
+) -> tuple[str, list[dict], list[str]]:
+    """Walk every ```shell``` block, run each `dragonfly>` invocation in
+    Docker, and substitute the lines following each invocation with the
+    actual output. Returns (new_text, errors, notes).
+
+    `FLUSHALL` is issued before every block so one example's keyspace
+    state cannot leak into another. Within a block, commands share state
+    (each subsequent `dragonfly>` line sees the keyspace left by the
+    previous one), which is what lets an example chain a SET and a GET.
+
+    `errors` is a list of {invocation, rc, stderr} for non-zero exits.
+    `notes` is a flat list of human-readable strings about the verification.
+    """
+    errors: list[dict] = []
+    notes: list[str] = []
+    out_parts: list[str] = []
+    last_pos = 0
+    invocation_count = 0
+    block_count = 0
+
+    for m in SHELL_BLOCK_RE.finditer(text):
+        out_parts.append(text[last_pos:m.start()])
+        # Clean slate per block. The reset is invisible to the reader of
+        # the doc — they just see each block start from an empty keyspace.
+        session.exec(["FLUSHALL"])
+        block_count += 1
+        body = m.group("body").rstrip("\n")
+        lines = body.split("\n")
+        rebuilt: list[str] = []
+        i = 0
+        while i < len(lines):
+            line = lines[i]
+            if not line.startswith("dragonfly> "):
+                # Lines before the first dragonfly> get passed through
+                # (e.g. comments at the start of a block).
+                rebuilt.append(line)
+                i += 1
+                continue
+            cmd = line[len("dragonfly> "):].strip()
+            argv = cmd.split()
+            stdout, stderr, rc = session.exec(argv)
+            invocation_count += 1
+            rebuilt.append(line)
+            actual = stdout if stdout else stderr
+            if actual:
+                rebuilt.extend(actual.split("\n"))
+            if rc != 0:
+                errors.append({
+                    "invocation": cmd,
+                    "rc": rc,
+                    "stderr": stderr,
+                })
+            # Skip the LLM's predicted output — keep walking until next
+            # `dragonfly>` line or end of block.
+            j = i + 1
+            while j < len(lines) and not lines[j].startswith("dragonfly> "):
+                j += 1
+            i = j
+        new_block = "```shell\n" + "\n".join(rebuilt) + "\n```"
+        out_parts.append(new_block)
+        last_pos = m.end()
+
+    out_parts.append(text[last_pos:])
+    new_text = "".join(out_parts)
+
+    if invocation_count:
+        notes.append(
+            f"verified {invocation_count} `dragonfly>` invocation(s) in "
+            f"{block_count} block(s) (FLUSHALL between blocks)"
+            + (f"; {len(errors)} non-zero exit(s)" if errors else "")
+        )
+    return new_text, errors, notes
+
+
+# --- Sibling style reference ------------------------------------------------
+
+_EXCLUDE_SIBLING_NAMES = frozenset({
+    "index.md", "_category_.md", "README.md",
+})
+
+
+def pick_sibling_style_reference(file_rel: str) -> tuple[str, str] | None:
+    """Pick a sibling page in the same directory to act as a visual style
+    template. We prefer the shortest sibling that has H2 sections — short
+    pages are cleaner templates and less likely to drown the prompt.
+    Returns (relative_path, full_text) or None if no sibling fits."""
+    target = (REPO_ROOT / file_rel).resolve()
+    parent = target.parent
+    candidates: list[tuple[int, Path, str]] = []
+    for f in parent.glob("*.md"):
+        if f == target or f.name in _EXCLUDE_SIBLING_NAMES:
+            continue
+        try:
+            text = f.read_text(encoding="utf-8")
+        except OSError:
+            continue
+        if len(text) < 200:
+            continue
+        if "\n## " not in text:
+            continue
+        candidates.append((len(text), f, text))
+    if not candidates:
+        return None
+    candidates.sort()
+    _, path, text = candidates[0]
+    if len(text) > 4000:
+        text = text[:4000] + "\n\n<!-- (sibling truncated for brevity) -->\n"
+    return str(path.relative_to(REPO_ROOT)), text
+
+
+# --- Phase 2: Update each file ----------------------------------------------
+
+UPDATE_SYSTEM = """\
+You are updating a single Dragonfly DB documentation page so that it matches
+the current state of the source code. Strict rules — violations make the
+page unusable:
+
+1. Only assert facts that are supported by the inputs you receive (the
+   current page, the source code excerpts, the Docker-verified examples,
+   the runtime facts, and the diff_context if provided). Never invent
+   options, return shapes, behaviors, complexities, or anything else.
+2. For complexity, give the GENERAL CASE only. Do not list edge cases.
+   If you cannot derive a clear general-case complexity from the source,
+   state the complexity in plain words instead of inventing a Big-O.
+3. Every example shown as a `dragonfly>` interaction inside a ```shell```
+   block (existing or new) is verified in Docker by the caller AFTER you
+   produce the markdown. The caller will replace the lines following
+   each `dragonfly>` line with the actual server output.
+
+   The caller issues `FLUSHALL` BEFORE each ```shell``` block so each
+   block starts from a clean keyspace — prior examples never leak into
+   the next one. Within a single block, state persists between
+   consecutive `dragonfly>` lines, so `SET k 1` followed by `GET k`
+   works as a chain.
+
+   Rules:
+     * Place new examples in their natural place — inside the page's
+       existing `## Examples` (or equivalent) section, beside related
+       existing examples. NEVER append a new fenced block at the bottom
+       of the page just to host a new example — that changes the page
+       structure.
+     * Each block should be SELF-CONTAINED. If demonstrating a command
+       requires keys / streams / sets to already exist, include the
+       setup commands at the top of the same block (e.g. write
+       `dragonfly> RPUSH mylist a b c` before `dragonfly> LRANGE mylist 0 -1`).
+       Extending an example with a few setup lines so the reader sees a
+       meaningful result is encouraged.
+     * For existing examples, you may keep them as-is or extend them
+       with setup lines to make them clearer. The caller re-verifies
+       every invocation either way.
+     * Do not invent commands you cannot justify from the source or
+       runtime facts.
+4. **Do NOT modify the `**ACL categor(y|ies):**` line.** That metadata
+   is owned by a separate tool (`acl_sync.py`). Leave it byte-identical
+   to what is in the input page — same prefix (with or without leading
+   dash), same category list, same order.
+5. **Do NOT change the page structure.** Keep every existing section in
+   its current position. Do not add new top-level (`##`) sections that
+   the input page does not already have. Do not move examples or any
+   content between sections. Do not split or merge sections. Change
+   CONTENT inside existing sections only.
+6. Preserve the page's frontmatter, `import PageTitle from ...` line,
+   and the `<PageTitle ...>` tag verbatim — they are required by the
+   site build.
+7. Preserve any human-written context that the source/Docker cannot
+   refute. If you cannot verify a claim and cannot disprove it, leave it
+   unchanged.
+8. Match the **existing visual style** of the page EXACTLY. The reader
+   must not be able to tell the page was edited just by looking at the
+   formatting. Specifically, do NOT change:
+     * heading levels or section hierarchy
+     * whether the metadata block uses bullets (`- **Time complexity:**`)
+       or plain (`**Time complexity:**`)
+     * how parameters are introduced (plain bullets vs
+       `<details><summary>` blocks)
+     * how examples are framed (with/without intro paragraph,
+       single-block vs per-step)
+     * link style (relative vs absolute, with/without titles)
+     * paragraph break conventions, list bullet character
+   You will receive a `sibling_style_reference` — another page from the
+   same category — purely as a style template. Match its conventions
+   when the input page has gaps. Never introduce a new style that
+   would make this page look different from its siblings. Change
+   CONTENT, not FORM.
+9. Cross-page link lists must already be at the END of the page if the
+   input has them. Do not move existing inline links into a list at the
+   end. Do not introduce a new "See also" section if the input does not
+   have one.
+10. Never write a bare `<placeholder>` token (e.g. `<key>`, `<pattern>`,
+    `<sha1>`) outside a fenced ``` ... ``` code block. Docusaurus parses
+    prose as MDX 3 and treats `<key>` as an unclosed JSX tag — the build
+    WILL fail. In prose, use inline code (`` `<key>` ``) or plain words
+    ("the key"). Standard HTML elements like `<details>`, `<summary>`,
+    `<code>`, `<b>` ARE allowed in prose because MDX recognizes them.
+11. If the source code, runtime facts, and Docker-verified examples all
+    confirm what the page already says, output the markdown BYTE-IDENTICAL
+    to the input. Do not rewrite for style; do not paraphrase; do not
+    add or remove blank lines that were already there. The caller skips
+    the disk write when the output equals the input — saving a no-op
+    edit. If you say in your `notes` that the output is byte-identical
+    to the input, then the markdown field MUST actually be byte-identical
+    — it is checked.
+12. NEVER reply with a placeholder like `...`, `TBD`, "see input", or
+    "unchanged from above" inside the `markdown` field. The `markdown`
+    field MUST contain the FULL page content, every line. The caller
+    rejects any output that is shorter than half of the input or that
+    is just an ellipsis — and treats that as a hard failure that
+    prevents the file from being written.
+
+If `diff_context` is present in your input it tells you which source
+commits motivated this update — focus the edit on what those commits
+changed. If `diff_context` is absent (e.g. this file came from a manual
+override), perform a full review against the current source state
+without assuming which areas need attention.
+
+Output JSON only. The first character must be `{` and the last must be `}`.
+No preamble, no markdown fences around the JSON, no explanation.
+
+Schema:
+
+  { "markdown": "<full updated page content>",
+    "notes":    ["<short bullet about a decision>", ...] }
+
+The caller verifies every `dragonfly>` invocation in your `markdown` by
+running it in a Docker container and substituting the captured output
+in place of whatever output you wrote. So you do not have to predict
+exact server output — but you DO have to put each example in the
+correct section (no appending blocks just to host examples).
+"""
+
+
+def build_update_user_text(
+    file_rel: str,
+    page_text: str,
+    handler_info: dict | None,
+    facts_entry: dict | None,
+    acl_categories: list[str],
+    docker_examples: list[dict],
+    sibling_style: tuple[str, str] | None = None,
+    diff_context: dict | None = None,
+) -> str:
+    parts = [
+        f"=== file_path ===\n{file_rel}",
+        "",
+        "=== current_page ===",
+        page_text,
+        "",
+    ]
+    if diff_context is not None:
+        parts += [
+            "=== diff_context (commits between the two tags that motivated "
+            "this update — focus your edit on what they changed) ===",
+            json.dumps(diff_context, indent=2, ensure_ascii=False),
+            "",
+        ]
+    else:
+        parts += [
+            "=== diff_context ===",
+            "(absent — this file came from a manual override; review the "
+            "current source state generally without assuming a focus area)",
+            "",
+        ]
+    if sibling_style is not None:
+        sib_path, sib_text = sibling_style
+        parts += [
+            "=== sibling_style_reference (do NOT copy content; only mirror "
+            "formatting / structure conventions) ===",
+            f"path: {sib_path}",
+            sib_text,
+            "",
+        ]
+    if handler_info:
+        parts += [
+            "=== source_handler (current state at the new tag) ===",
+            f"file: {handler_info['file']}",
+            f"registration_line: {handler_info['registration_line']}",
+            f"function: {handler_info['handler_function']}",
+            "body:",
+            handler_info["handler_body"],
+            "",
+        ]
+    if facts_entry:
+        parts += [
+            "=== runtime_facts (COMMAND output) ===",
+            json.dumps(facts_entry, indent=2),
+            "",
+        ]
+    if acl_categories:
+        parts += [
+            "=== acl_categories (informational only — DO NOT modify the "
+            "ACL line in the page; this is owned by acl_sync.py) ===",
+            ", ".join(sorted(acl_categories)),
+            "",
+        ]
+    parts += [
+        "=== docker_verified_examples (existing examples already verified) ===",
+        json.dumps(docker_examples, indent=2, ensure_ascii=False),
+        "",
+        "=== task ===",
+        "Produce the JSON {markdown, notes}. JSON only.",
+    ]
+    return "\n".join(parts)
+
+
+def needs_emulated_cluster(handler_info: dict | None, command: str | None) -> bool:
+    if command and command.split()[0] in {"CLUSTER", "READONLY", "READWRITE",
+                                           "DFLYCLUSTER"}:
+        return True
+    if handler_info and "cluster_family.cc" in handler_info.get("file", ""):
+        return True
+    return False
+
+
+def update_one_file(
+    entry: dict,
+    after_tag: str,
+    facts: dict,
+    src: Path,
+    skip_pull: bool,
+    dry_run: bool,
+) -> dict:
+    """Update one file. Returns a result record."""
+    rel = entry["path"]
+    abs_path = REPO_ROOT / rel
+    result: dict = {
+        "path": rel,
+        "status": "pending",
+        "reason_input": entry.get("reason", ""),
+        "notes": [],
+    }
+    if not abs_path.exists():
+        result["status"] = "missing"
+        result["error"] = f"file not found: {rel}"
+        return result
+
+    page_text = abs_path.read_text(encoding="utf-8")
+    h1 = extract_h1(page_text)
+    command = h1.upper() if h1 else None
+    facts_entry = facts.get("data", {}).get("commands", {}).get(command)
+    acl_cats = facts.get("data", {}).get("command_acl", {}).get(command, [])
+    handler_info = (find_command_handler_source(src, command) if command else None)
+
+    invocations = extract_redis_invocations(page_text)
+    docker_examples: list[dict] = []
+    session = None
+    is_command_page = bool(facts_entry)
+    needs_docker = bool(invocations) or is_command_page
+
+    if needs_docker:
+        emu = needs_emulated_cluster(handler_info, command)
+        try:
+            session = boot_docker(after_tag, emulated_cluster=emu,
+                                  skip_pull=skip_pull)
+        except Exception as e:
+            result["notes"].append(f"docker boot failed: {e}; "
+                                   f"verifying examples skipped")
+            session = None
+    if session and invocations:
+        docker_examples = verify_invocations(session, invocations)
+
+    try:
+        try:
+            import anthropic
+        except ImportError:
+            result["status"] = "skipped"
+            result["error"] = "anthropic SDK not installed"
+            return result
+        if not os.getenv("ANTHROPIC_API_KEY"):
+            result["status"] = "skipped"
+            result["error"] = "ANTHROPIC_API_KEY not set"
+            return result
+        client = anthropic.Anthropic()
+        sibling_style = pick_sibling_style_reference(rel)
+        if sibling_style:
+            result["notes"].append(
+                f"using sibling style reference: {sibling_style[0]}"
+            )
+        diff_context = entry.get("diff_context")
+        if diff_context:
+            result["notes"].append(
+                f"using diff_context ({len(diff_context.get('commits_per_file', []))} "
+                f"related source file(s))"
+            )
+        user_text = build_update_user_text(
+            rel, page_text, handler_info, facts_entry, acl_cats,
+            docker_examples, sibling_style, diff_context,
+        )
+        print(f"  -> {rel}: calling Claude...")
+        parsed, usage = call_llm_streaming(
+            client, UPDATE_SYSTEM, user_text, UPDATE_MAX_TOKENS,
+            f"update_{re.sub(r'[^a-z0-9]+', '_', rel.lower())[:60]}",
+        )
+        print(f"     tokens: in={usage['input_tokens']} "
+              f"out={usage['output_tokens']}")
+        new_md = parsed.get("markdown", "")
+        notes = parsed.get("notes", []) or []
+        result["notes"].extend(notes)
+
+        if not new_md.strip():
+            result["status"] = "failed"
+            result["error"] = "LLM returned empty markdown"
+            return result
+
+        # Structural validation — catches catastrophic LLM failures like
+        # returning `...`, truncating mid-document, or losing required
+        # structure. Run BEFORE Docker verification because we don't want
+        # to spend Docker time on garbage output.
+        struct_errors = validate_update_output(page_text, new_md)
+        if struct_errors:
+            LLM_DEBUG_DIR.mkdir(parents=True, exist_ok=True)
+            ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+            slug = re.sub(r"[^a-z0-9]+", "_", rel.lower())[:60]
+            debug = LLM_DEBUG_DIR / f"docs_sync_rejected_{slug}_{ts}.md"
+            debug.write_text(new_md, encoding="utf-8")
+            result["status"] = "failed"
+            result["error"] = (
+                f"structural validation failed: {struct_errors}; "
+                f"raw LLM markdown saved to "
+                f"{debug.relative_to(REPO_ROOT)}"
+            )
+            return result
+
+        # Verify every `dragonfly>` invocation in the LLM's markdown — both
+        # the existing examples and any new ones the LLM placed in their
+        # proper section — by running each in Docker and substituting the
+        # actual output.
+        if session:
+            new_md, exec_errors, exec_notes = verify_and_substitute_examples(
+                new_md, session,
+            )
+            result["notes"].extend(exec_notes)
+            if exec_errors:
+                result["notes"].append(
+                    f"{len(exec_errors)} invocation(s) had non-zero exit; "
+                    f"server output (stderr) substituted as the example "
+                    f"output: {[e['invocation'] for e in exec_errors[:5]]}"
+                    + ("..." if len(exec_errors) > 5 else "")
+                )
+
+        # MDX safety: wrap bare `<placeholder>` tokens, convert indented
+        # code-with-placeholders to fenced text blocks.
+        safe_md = fix_mdx_jsx_unsafe(new_md)
+        if safe_md != new_md:
+            result["notes"].append(
+                "applied MDX safety pass (wrapped placeholders / "
+                "fenced indented blocks)"
+            )
+            new_md = safe_md
+
+        # No-change-skip: if the final markdown equals the input — exactly
+        # or after stripping cosmetic-only differences (trailing spaces,
+        # collapsed blank-line runs) — the page already matches reality.
+        # Do not write a no-op edit, the git diff would be pure noise.
+        if new_md == page_text:
+            result["status"] = "unchanged"
+            result["notes"].append(
+                "page already matches source/Docker — no write performed"
+            )
+            return result
+        if normalize_for_compare(new_md) == normalize_for_compare(page_text):
+            result["status"] = "unchanged"
+            result["notes"].append(
+                "page differs from input only in whitespace — no write performed"
+            )
+            return result
+
+        if not dry_run:
+            abs_path.write_text(new_md, encoding="utf-8")
+        result["status"] = "updated"
+    finally:
+        if session:
+            kill_docker(session)
+    return result
+
+
+def update_phase(plan: dict, after_tag: str, skip_pull: bool, dry_run: bool,
+                 filter_glob: str = "") -> list[dict]:
+    print(f"\n[Phase 2] Update {len(plan['files_to_update'])} file(s) "
+          f"against tag {after_tag}")
+    src = ensure_dragonfly_checkout(after_tag)
+
+    # Load facts
+    facts_path = FACTS_DIR / f"{after_tag}.json"
+    if not facts_path.exists():
+        print(f"  capturing facts via dfly_facts.py...")
+        cmd = ["python3", str(DFLY_FACTS), "--tag", after_tag]
+        if skip_pull:
+            cmd.append("--skip-pull")
+        subprocess.run(cmd, check=True)
+    facts = json.loads(facts_path.read_text(encoding="utf-8"))
+
+    results: list[dict] = []
+    entries = plan["files_to_update"]
+    if filter_glob:
+        entries = [e for e in entries if fnmatch(e["path"], filter_glob)]
+    for entry in entries:
+        try:
+            results.append(update_one_file(
+                entry, after_tag, facts, src, skip_pull, dry_run,
+            ))
+        except Exception as e:
+            results.append({
+                "path": entry["path"],
+                "status": "error",
+                "error": str(e),
+                "notes": [],
+            })
+    return results
+
+
+# --- Main --------------------------------------------------------------------
+
+def parse_also_update(path: Path | None) -> list[str]:
+    if not path:
+        return []
+    out: list[str] = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        s = line.strip()
+        if not s or s.startswith("#"):
+            continue
+        out.append(s)
+    return out
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--before", help="Older Dragonfly tag.")
+    ap.add_argument("--after", help="Newer Dragonfly tag.")
+    ap.add_argument("--also-update", type=Path,
+                    help="Text file with paths to force-include in the plan, "
+                         "one per line.")
+    ap.add_argument("--filter", default="",
+                    help="Glob to limit which md files are processed.")
+    ap.add_argument("--discover-only", action="store_true",
+                    help="Run Phase 1 only; print the plan and exit.")
+    ap.add_argument("--update-only-from", type=Path,
+                    help="Skip Phase 1; load this saved plan JSON and run "
+                         "Phase 2 against it.")
+    ap.add_argument("--skip-pull", action="store_true",
+                    help="Skip docker pull for the Dragonfly image.")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Do not write any updated files.")
+    args = ap.parse_args()
+
+    if args.update_only_from:
+        plan = json.loads(args.update_only_from.read_text(encoding="utf-8"))
+        plan["_plan_path"] = str(args.update_only_from.resolve()
+                                 .relative_to(REPO_ROOT))
+        after_tag = plan.get("after") or args.after
+        if not after_tag:
+            ap.error("--update-only-from plan has no `after` tag and "
+                     "--after not given")
+    else:
+        if not args.before or not args.after:
+            ap.error("--before and --after are required (unless "
+                     "--update-only-from is used)")
+        also = parse_also_update(args.also_update)
+        plan = discover_phase(args.before, args.after, also, args.filter)
+        if args.discover_only:
+            print("\n--- Plan summary ---")
+            for entry in plan["files_to_update"]:
+                print(f"  {entry['path']}")
+                print(f"    reason: {entry.get('reason', '')}")
+            return 0
+        after_tag = args.after
+
+    results = update_phase(plan, after_tag, args.skip_pull, args.dry_run,
+                           args.filter)
+
+    counters = {"updated": 0, "unchanged": 0, "failed": 0, "skipped": 0,
+                "missing": 0, "error": 0}
+    for r in results:
+        counters[r["status"]] = counters.get(r["status"], 0) + 1
+    print(f"\n--- Phase 2 summary ---")
+    for k, v in counters.items():
+        if v:
+            print(f"  {k}: {v}")
+    if counters.get("failed") or counters.get("error"):
+        print("\nFailures:")
+        for r in results:
+            if r["status"] in ("failed", "error"):
+                print(f"  {r['path']}: {r.get('error', '?')}")
+
+    PLANS_DIR.mkdir(parents=True, exist_ok=True)
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    results_path = PLANS_DIR / f"results_{ts}.json"
+    results_path.write_text(
+        json.dumps({
+            "plan_path": plan.get("_plan_path"),
+            "after": after_tag,
+            "results": results,
+        }, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    print(f"\nResults saved: {results_path.relative_to(REPO_ROOT)}")
+    return 0 if not (counters.get("failed") or counters.get("error")) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/docsync/flags_sync.py
+++ b/tools/docsync/flags_sync.py
@@ -1,0 +1,1192 @@
+#!/usr/bin/env python3
+"""flags_sync.py — Synchronize docs/managing-dragonfly/flags.md with reality.
+
+Three-stage pipeline:
+
+  1. Capture facts. Two sources:
+       a) Docker (`dfly_facts.py`) — authoritative for default values, types,
+          groups, and the short ABSL_FLAG help string.
+       b) Source code (parsed inline) — provides the ABSL_FLAG declaration's
+          file/line, surrounding C++ comment block, and (when the flag's type
+          is an enum) the enum's value list with comments. This is what gives
+          the LLM enough context to write quality descriptions for new flags
+          and to expand enum-typed defaults like `compression_mode = 3` into
+          something a reader can actually understand.
+
+  2. Mechanical pass.
+     a) Delete sections for flags the server no longer reports (the binary
+        is the authoritative source — if a flag isn't there the doc was
+        wrong).
+     b) For each remaining flag, replace the single `default: ...` line if
+        the value differs. A byte-equivalence check skips cosmetic
+        reformatting (`0` vs `0B`, `128MiB` vs `128.00MiB`).
+     **Enum-typed defaults** (doc has a number, server reports an uppercase
+     enum constant) are NOT mechanically rewritten — keeping the integer is
+     better for the CLI reader, and the LLM polish is responsible for adding
+     the enum-value table to the description.
+
+  3. LLM polish. Claude receives the mechanically-fixed page (already with
+     obsolete flags removed and defaults updated), the ground-truth dict
+     restricted to flags that should be in the output, the source-code data
+     per flag, and explicit instructions: add missing flags using their
+     ABSL_FLAG help and any surrounding C++ comment context; for enum-typed
+     defaults, expand the description with a value table; preserve
+     human-written content. The output is validated (every flag present,
+     defaults match modulo equivalence, no duplicates) — if validation
+     fails the LLM output is discarded and the mechanical-only result
+     stays on disk. A post-process pass also auto-deduplicates flag
+     sections in case the LLM emits stub copies.
+
+Usage:
+    python tools/docsync/flags_sync.py --tag v1.38.0
+    python tools/docsync/flags_sync.py --tag v1.38.0 --dry-run
+    python tools/docsync/flags_sync.py --tag v1.38.0 --no-llm
+    python tools/docsync/flags_sync.py --tag v1.38.0 --skip-source
+    python tools/docsync/flags_sync.py --facts tools/generated/facts/v1.38.0.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+FLAGS_PAGE = REPO_ROOT / "docs" / "managing-dragonfly" / "flags.md"
+FACTS_DIR = REPO_ROOT / "tools" / "generated" / "facts"
+SOURCE_DIR = REPO_ROOT / "tools" / "generated" / "source"
+DFLY_FACTS = REPO_ROOT / "tools" / "docsync" / "dfly_facts.py"
+
+DRAGONFLY_REPO = "https://github.com/dragonflydb/dragonfly.git"
+DRAGONFLY_CHECKOUT = Path("/tmp/dragonfly-docsync")
+
+MODEL = "claude-sonnet-4-6"
+MAX_TOKENS = 32000
+
+SECTION_RE = re.compile(
+    r"^###[ \t]+`--(?P<name>[a-z][a-z0-9_]*)`[ \t]*\n"
+    r"(?P<body>.*?)(?=^###[ \t]+`--|\Z)",
+    re.DOTALL | re.MULTILINE,
+)
+DEFAULT_RE = re.compile(r"`default:\s*(?P<v>[^`]*)`")
+
+# Flags declared in upstream libraries are not part of Dragonfly's documented
+# surface. They show up in --helpfull because Dragonfly statically links the
+# glog / absl libraries, but they are general-purpose logging / argument
+# plumbing flags (--v, --vmodule, --alsologtoemail, --colorlogtostdout,
+# --symbolize_stacktrace, --fromenv, --tryfromenv, --undefok, ...). Hiding
+# them from auto-add prevents the LLM polish from polluting flags.md with
+# upstream-library noise.
+UPSTREAM_GROUP_PREFIXES = (
+    "glog-src/",
+    "abseil_cpp-src/",
+)
+
+
+def run(cmd: list[str], cwd: Path | None = None,
+        check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True, check=check)
+
+
+def filter_user_facing(flags: dict[str, dict]) -> dict[str, dict]:
+    out: dict[str, dict] = {}
+    for name, info in flags.items():
+        group = info.get("group") or ""
+        if any(group.startswith(p) for p in UPSTREAM_GROUP_PREFIXES):
+            continue
+        out[name] = info
+    return out
+
+
+# --- Value-equivalence (so cosmetic byte reformatting isn't a fix) -----------
+
+_BYTE_UNIT_TO_BYTES: dict[str, int] = {
+    "":  1,  "b":   1,
+    "k": 1024, "kb": 1024, "kib": 1024,
+    "m": 1024 ** 2, "mb": 1024 ** 2, "mib": 1024 ** 2,
+    "g": 1024 ** 3, "gb": 1024 ** 3, "gib": 1024 ** 3,
+    "t": 1024 ** 4, "tb": 1024 ** 4, "tib": 1024 ** 4,
+}
+_BYTE_VALUE_RE = re.compile(r"^\s*(-?\d+(?:\.\d+)?)\s*([A-Za-z]*)\s*$")
+
+
+def _parse_byte_value(s: str) -> int | None:
+    m = _BYTE_VALUE_RE.match(s)
+    if not m:
+        return None
+    unit = m.group(2).lower()
+    if unit not in _BYTE_UNIT_TO_BYTES:
+        return None
+    return int(round(float(m.group(1)) * _BYTE_UNIT_TO_BYTES[unit]))
+
+
+def values_equivalent(a: str, b: str) -> bool:
+    """True if `a` and `b` represent the same value modulo byte-unit
+    formatting (`0` == `0B`, `128MiB` == `128.00MiB`, `65536` == `64.0KiB`).
+    Returns False for anything we cannot prove equal."""
+    if a.strip() == b.strip():
+        return True
+    ab = _parse_byte_value(a)
+    bb = _parse_byte_value(b)
+    return ab is not None and ab == bb
+
+
+_ENUM_NAME_RE = re.compile(r"^[A-Z][A-Z0-9_]*$")
+_INT_RE = re.compile(r"^-?\d+$")
+
+
+def is_enum_change(doc: str, server: str) -> bool:
+    """True if the doc has an integer default and the server reports an
+    UPPERCASE_ENUM constant. We do NOT mechanically apply such changes —
+    a number is a more useful default for a CLI reader, and the LLM polish
+    will expand the description with the enum-value table."""
+    return bool(_INT_RE.match(doc.strip()) and _ENUM_NAME_RE.match(server.strip()))
+
+
+# --- Section parsing ---------------------------------------------------------
+
+@dataclass
+class FlagSection:
+    name: str
+    span: tuple[int, int]
+    body: str
+    default: str | None
+
+
+@dataclass
+class MechResult:
+    fixed_defaults: list[tuple[str, str, str]] = field(default_factory=list)
+    failed_defaults: list[tuple[str, str]] = field(default_factory=list)
+    deferred_enum: list[tuple[str, str, str]] = field(default_factory=list)  # (name, doc, server)
+    removed_from_doc: list[str] = field(default_factory=list)  # in doc, no longer on server — deleted
+    missing_from_doc: list[str] = field(default_factory=list)
+
+
+def parse_sections(text: str) -> dict[str, FlagSection]:
+    out: dict[str, FlagSection] = {}
+    for m in SECTION_RE.finditer(text):
+        name = m.group("name")
+        body = m.group("body")
+        dm = DEFAULT_RE.search(body)
+        default = dm.group("v").strip() if dm else None
+        out[name] = FlagSection(
+            name=name, span=(m.start(), m.end()),
+            body=body, default=default,
+        )
+    return out
+
+
+# --- Source code parsing (inline) -------------------------------------------
+
+def ensure_dragonfly_checkout(tag: str, refresh: bool) -> Path:
+    """Ensure /tmp/dragonfly-docsync is a clean checkout at `tag`."""
+    if not (DRAGONFLY_CHECKOUT / ".git").exists():
+        DRAGONFLY_CHECKOUT.parent.mkdir(parents=True, exist_ok=True)
+        print(f"  cloning Dragonfly source to {DRAGONFLY_CHECKOUT}...")
+        run(["git", "clone", "--quiet", DRAGONFLY_REPO, str(DRAGONFLY_CHECKOUT)])
+    if refresh:
+        run(["git", "fetch", "--tags", "--quiet"], cwd=DRAGONFLY_CHECKOUT, check=False)
+    # `git checkout <tag>` is idempotent and quiet
+    run(["git", "checkout", "--quiet", tag], cwd=DRAGONFLY_CHECKOUT, check=False)
+    return DRAGONFLY_CHECKOUT
+
+
+def _split_top_level_commas(body: str) -> list[int]:
+    """Indices of `,` at paren depth 0, ignoring chars in strings/chars."""
+    out: list[int] = []
+    depth = 0
+    in_str: str | None = None
+    i = 0
+    while i < len(body):
+        c = body[i]
+        if in_str:
+            if c == "\\" and i + 1 < len(body):
+                i += 2
+                continue
+            if c == in_str:
+                in_str = None
+        elif c in ('"', "'"):
+            in_str = c
+        elif c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+        elif c == "," and depth == 0:
+            out.append(i)
+        i += 1
+    return out
+
+
+def _find_matching_paren(text: str, open_pos: int) -> int:
+    """Return position of `)` matching `(` at open_pos, or -1."""
+    depth = 0
+    in_str: str | None = None
+    i = open_pos
+    while i < len(text):
+        c = text[i]
+        if in_str:
+            if c == "\\" and i + 1 < len(text):
+                i += 2
+                continue
+            if c == in_str:
+                in_str = None
+        elif c in ('"', "'"):
+            in_str = c
+        elif c == "(":
+            depth += 1
+        elif c == ")":
+            depth -= 1
+            if depth == 0:
+                return i
+        i += 1
+    return -1
+
+
+_STRING_LITERAL_RE = re.compile(r'"((?:[^"\\]|\\.)*)"', re.DOTALL)
+
+
+def _join_string_literals(s: str) -> str:
+    """Concatenate adjacent C++ string literals: `"foo" "bar"` -> `foobar`."""
+    parts = _STRING_LITERAL_RE.findall(s)
+    if not parts:
+        return s.strip().strip(';').strip()
+    # Unescape \n, \t, \\
+    joined = "".join(p for p in parts)
+    return re.sub(r"\\(.)", r"\1", joined)
+
+
+def _comments_above(text: str, line_start: int) -> str:
+    """Collect contiguous `// ...` lines and `/* ... */` block above `line_start`."""
+    lines_before = text[:line_start].split("\n")
+    out: list[str] = []
+    in_block = False
+    for line in reversed(lines_before):
+        stripped = line.strip()
+        if not out and stripped == "":
+            continue
+        if stripped.startswith("//"):
+            out.insert(0, stripped[2:].strip())
+            continue
+        if stripped.endswith("*/"):
+            out.insert(0, stripped)
+            in_block = True
+            continue
+        if in_block:
+            out.insert(0, stripped)
+            if stripped.startswith("/*"):
+                in_block = False
+            continue
+        break
+    return "\n".join(out)
+
+
+def parse_absl_flags(text: str) -> list[dict]:
+    """Yield each ABSL_FLAG declaration as
+    {name, type, default_expr, description, comments, line}."""
+    out: list[dict] = []
+    for m in re.finditer(r"\bABSL_FLAG\s*\(", text):
+        open_paren = m.end() - 1
+        close_paren = _find_matching_paren(text, open_paren)
+        if close_paren < 0:
+            continue
+        body = text[open_paren + 1:close_paren]
+        commas = _split_top_level_commas(body)
+        if len(commas) < 3:
+            continue
+        type_str = body[:commas[0]].strip()
+        name = body[commas[0] + 1:commas[1]].strip()
+        default_expr = body[commas[1] + 1:commas[2]].strip()
+        desc_raw = body[commas[2] + 1:].strip()
+        if not name or not name.replace("_", "").isalnum():
+            continue
+        line_start = text.rfind("\n", 0, m.start()) + 1
+        comments = _comments_above(text, line_start)
+        out.append({
+            "name": name,
+            "type": type_str,
+            "default_expr": default_expr,
+            "description": _join_string_literals(desc_raw),
+            "comments": comments,
+            "line": text.count("\n", 0, m.start()) + 1,
+        })
+    return out
+
+
+def parse_enum_definitions(text: str) -> dict[str, list[dict]]:
+    """Find `enum [class] Name [: type] { values };` blocks. Return
+    {name: [{name, value, comment}, ...]}.
+
+    For implicit enum values (no `= N`), assign the standard C++ positional
+    value (0 for the first, prev+1 thereafter). When a value is explicit
+    we record the source expression as a string and resume incrementing
+    from the parsed integer if the expression is a plain integer.
+    """
+    out: dict[str, list[dict]] = {}
+    pat = re.compile(
+        r"\benum\s+(?:class\s+|struct\s+)?(?P<name>[A-Z][A-Za-z0-9_]*)"
+        r"(?:\s*:\s*[\w:]+)?\s*\{(?P<body>[^}]*)\}\s*;",
+        re.DOTALL,
+    )
+    for m in pat.finditer(text):
+        body = m.group("body")
+        values: list[dict] = []
+        next_implicit = 0
+        for raw in body.split(","):
+            line = raw.strip()
+            if not line:
+                continue
+            comment = ""
+            cmt_m = re.search(r"//(.*)$", line)
+            if cmt_m:
+                comment = cmt_m.group(1).strip()
+                line = line[:cmt_m.start()].rstrip()
+            if "=" in line:
+                nm, _, vl = line.partition("=")
+                vl = vl.strip()
+                # If the value is a plain integer, use it & resume incrementing.
+                try:
+                    next_implicit = int(vl, 0) + 1
+                    value_str = vl
+                except ValueError:
+                    value_str = vl  # leave non-integer expression as-is
+                values.append({"name": nm.strip(), "value": value_str, "comment": comment})
+            else:
+                values.append({"name": line.strip(), "value": str(next_implicit),
+                               "comment": comment})
+                next_implicit += 1
+        if values:
+            out[m.group("name")] = values
+    return out
+
+
+def _enum_type_token(type_str: str) -> str | None:
+    """For type strings like `dfly::CompressionMode`, return `CompressionMode`.
+    For primitive types (bool, int, std::string) return None."""
+    bare = type_str.split("::")[-1].strip().rstrip("&*")
+    if bare in {"bool", "int", "int32_t", "int64_t", "uint32_t", "uint64_t",
+                "uint16_t", "uint8_t", "size_t", "double", "float", "string"}:
+        return None
+    if not re.match(r"^[A-Z][A-Za-z0-9_]*$", bare):
+        return None
+    return bare
+
+
+def extract_source_facts(
+    src: Path, target_names: set[str], verbose: bool = True,
+) -> dict[str, dict]:
+    """Scan dragonfly source, return {flag_name: {file, line, type,
+    default_expr, description, comments, enum_values?}} for every
+    ABSL_FLAG whose name is in `target_names`."""
+    if verbose:
+        print(f"  scanning C++ source under {src}...")
+    grep = subprocess.run(
+        ["grep", "-rln", "ABSL_FLAG", str(src),
+         "--include=*.cc", "--include=*.h"],
+        capture_output=True, text=True, check=False,
+    )
+    files = [Path(p) for p in grep.stdout.splitlines() if p]
+    flags: dict[str, dict] = {}
+    enum_pool: dict[str, list[dict]] = {}
+    for f in files:
+        try:
+            text = f.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        for decl in parse_absl_flags(text):
+            if decl["name"] not in target_names:
+                continue
+            decl["file"] = str(f.relative_to(src))
+            flags[decl["name"]] = decl
+        enum_pool.update(parse_enum_definitions(text))
+    # Also walk header files that didn't contain ABSL_FLAG (for enums).
+    for f in src.rglob("*.h"):
+        try:
+            text = f.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        enum_pool.update(parse_enum_definitions(text))
+    for name, info in flags.items():
+        token = _enum_type_token(info["type"])
+        if token and token in enum_pool:
+            info["enum_values"] = enum_pool[token]
+            info["enum_name"] = token
+    if verbose:
+        with_enum = sum(1 for v in flags.values() if "enum_values" in v)
+        print(f"  parsed {len(flags)} ABSL_FLAG declaration(s); "
+              f"{with_enum} have an enum-typed default")
+    return flags
+
+
+def load_or_capture_source(args: argparse.Namespace,
+                           target_names: set[str]) -> dict[str, dict]:
+    cache = SOURCE_DIR / f"{args.tag}.json"
+    if cache.exists() and not args.refresh_source:
+        cached = json.loads(cache.read_text(encoding="utf-8"))
+        # Cache covers all flags; intersect with current targets
+        return {n: cached[n] for n in target_names if n in cached}
+    src = ensure_dragonfly_checkout(args.tag, refresh=args.refresh_source)
+    facts = extract_source_facts(src, target_names)
+    SOURCE_DIR.mkdir(parents=True, exist_ok=True)
+    tmp = cache.with_suffix(cache.suffix + ".tmp")
+    tmp.write_text(
+        json.dumps(facts, indent=2, sort_keys=True, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    os.replace(tmp, cache)
+    return facts
+
+
+# --- Facts loading -----------------------------------------------------------
+
+def load_facts(args: argparse.Namespace) -> dict:
+    if args.facts:
+        return json.loads(args.facts.read_text(encoding="utf-8"))
+    facts_path = FACTS_DIR / f"{args.tag}.json"
+    if facts_path.exists() and not args.refresh_facts:
+        print(f"  using cached facts: {facts_path.relative_to(REPO_ROOT)}")
+        return json.loads(facts_path.read_text(encoding="utf-8"))
+    cmd = ["python3", str(DFLY_FACTS), "--tag", args.tag]
+    if args.skip_pull:
+        cmd.append("--skip-pull")
+    print("  capturing facts via dfly_facts.py...")
+    p = subprocess.run(cmd)
+    if p.returncode != 0 or not facts_path.exists():
+        raise RuntimeError("dfly_facts capture failed")
+    return json.loads(facts_path.read_text(encoding="utf-8"))
+
+
+# --- Mechanical pass ---------------------------------------------------------
+
+def patch_default(text: str, section: FlagSection, new_default: str) -> str | None:
+    s, e = section.span
+    section_text = text[s:e]
+    new_section, count = DEFAULT_RE.subn(
+        f"`default: {new_default}`", section_text, count=1,
+    )
+    if count != 1:
+        return None
+    return text[:s] + new_section + text[e:]
+
+
+def mechanical_pass(
+    text: str,
+    all_server_flags: dict[str, dict],
+    user_facing_flags: dict[str, dict],
+) -> tuple[str, MechResult]:
+    """Two stages on the page text:
+      1. Remove sections for flags the server no longer reports — these are
+         obsolete and the server is the authoritative source.
+      2. Fix `default: ...` lines for the remaining flags whose default
+         value drifted.
+    """
+    result = MechResult()
+    sections = parse_sections(text)
+
+    doc_names = set(sections.keys())
+    all_server_names = set(all_server_flags.keys())
+    user_facing_names = set(user_facing_flags.keys())
+
+    result.missing_from_doc = sorted(user_facing_names - doc_names)
+    result.removed_from_doc = sorted(doc_names - all_server_names)
+
+    # Stage 1: delete obsolete sections. Walk in reverse position so earlier
+    # spans remain valid as we mutate the text.
+    if result.removed_from_doc:
+        for name in sorted(result.removed_from_doc,
+                           key=lambda n: -sections[n].span[0]):
+            s, e = sections[name].span
+            text = text[:s] + text[e:]
+        # Re-parse for stage 2 since spans have shifted.
+        sections = parse_sections(text)
+
+    # Stage 2: fix defaults for flags still in both doc and server.
+    remaining = set(sections.keys()) & all_server_names
+    for name in sorted(remaining, key=lambda n: -sections[n].span[0]):
+        sec = sections[name]
+        server_default = all_server_flags[name].get("default", "")
+        if sec.default is None:
+            result.failed_defaults.append((name, "section has no `default: ...` line"))
+            continue
+        if values_equivalent(sec.default, server_default):
+            continue
+        if is_enum_change(sec.default, server_default):
+            # Defer: keep the integer in `default:`, let the LLM polish add
+            # an enum-value table to the description instead.
+            result.deferred_enum.append((name, sec.default, server_default))
+            continue
+        new_text = patch_default(text, sec, server_default)
+        if new_text is None:
+            result.failed_defaults.append(
+                (name, "could not substitute `default:` (matches != 1)"),
+            )
+            continue
+        text = new_text
+        result.fixed_defaults.append((name, sec.default, server_default))
+
+    return text, result
+
+
+# --- LLM polish --------------------------------------------------------------
+
+POLISH_SYSTEM = """\
+You are polishing a Dragonfly DB flag-reference page (docs/managing-dragonfly/flags.md).
+
+You will receive:
+  - The current page (already mechanically reconciled — every default value
+    you see for an existing flag has been pre-fixed and is authoritative).
+  - `must_be_present`: the EXACT list of flag names whose `### `--<name>``
+    section must appear in the output. Not a subset, not a superset —
+    EXACTLY this list. Treat it as the closed-world set.
+  - `ground_truth`: dict { flag_name -> { default, description, type, group } }
+    captured from the running binary's `--helpfull`. Restricted to
+    `must_be_present` plus a few flags the page already documents that the
+    server still reports. `description` is verbatim help text.
+  - `source_facts`: dict { flag_name -> { type, default_expr, description,
+    comments, file, line, enum_name?, enum_values? } } captured from the
+    Dragonfly C++ source. Restricted to the same set as `ground_truth`.
+    `comments` are the C++ comments immediately above the ABSL_FLAG
+    declaration; they often contain rationale. `enum_values` is present
+    only when the flag's type is an enum; each entry has { name, value,
+    comment }.
+  - `flags_to_add`: subset of `must_be_present` — flags the server reports
+    that are NOT yet in the page; you must write new sections for these.
+  - `enum_defaults_to_expand`: list of { flag, doc_default, server_default }.
+    For each, the page's `default:` MUST stay as the integer (it is what the
+    CLI accepts). The flag's description in the polished page MUST list the
+    enum's values, e.g.:
+
+        `default: 3`
+
+        Where:
+        - `0` — `NONE` — single-entry, no compression.
+        - `2` — `SINGLE_ENTRY_LZ4` — ...
+        - `3` — `MULTI_ENTRY_LZ4` — ...
+
+    Use the `enum_values` data from `source_facts` to populate the table;
+    do NOT invent a meaning that's not in the comments or enum names.
+
+Hard rules:
+  1. The output MUST contain a `### `--<name>`` section for EXACTLY the
+     flags in `must_be_present`. Adding a flag not in this list is a
+     fatal error. Omitting one is a fatal error. The set must match
+     character-for-character.
+  2. Every `default: X` line in the output MUST equal `ground_truth[name].default`
+     (modulo byte-equivalence — `0` ≡ `0B`, `128MiB` ≡ `128.00MiB`).
+     EXCEPTION: for flags listed in `enum_defaults_to_expand`, the
+     `default:` line MUST be the integer `doc_default` (e.g. `3`), NOT the
+     enum name. The enum name and meaning go in the description body.
+  3. For flags already documented: prefer the existing description. If the
+     `--helpfull` text or `source_facts.comments` adds useful detail not
+     already covered, integrate it sparingly. Do not rewrite for style.
+  4. For flags in `flags_to_add`: write a clear, neutral description using
+     `--helpfull` text + `source_facts.comments`. Do not invent capabilities
+     beyond what those texts say.
+  5. Preserve every non-flag piece (intro paragraphs, headings, examples).
+  6. Section ordering: keep already-present flags in their current positions.
+     Place newly-added flags near related flags (by `group`) when an obvious
+     anchor exists; otherwise at the end of `## Available Flags`.
+  7. Each flag MUST appear EXACTLY ONCE. Do NOT emit "see above" stubs,
+     consolidated index sections, or any duplicate `### `--<name>`` headers.
+     The output is parsed by counting `### `--name`` occurrences; two for
+     the same name fails the check. If you find yourself tempted to
+     reference a flag again later in the page, instead leave just the
+     single canonical section and link to it from surrounding prose.
+
+Your response MUST be a single JSON object and NOTHING else. The very first
+character of your response must be `{` and the very last must be `}`. No
+preamble like "I'll analyze the inputs", no closing remark, no markdown
+fences (```), no explanation. The schema:
+
+  { "markdown": "<full file content>",
+    "notes":    ["<short bullet about decisions you made>", ...] }
+
+If you violate this format the downstream parser will discard your work.
+"""
+
+
+def _extract_json_object(text: str) -> dict | None:
+    """Best-effort extraction of a top-level JSON object from `text`.
+
+    Handles the common LLM failure modes:
+      * verbatim JSON (no wrapping)               -> json.loads(text)
+      * preamble before / after the JSON          -> slice between first { and matching }
+      * ```json ... ``` fence                     -> extract fenced block
+    Returns the parsed dict, or None if nothing parseable was found.
+    """
+    text = text.strip()
+
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError:
+        pass
+
+    fence = re.search(r"```(?:json|JSON)?\s*\n(.*?)\n```", text, re.DOTALL)
+    if fence:
+        try:
+            return json.loads(fence.group(1).strip())
+        except json.JSONDecodeError:
+            pass
+
+    depth = 0
+    in_str: str | None = None
+    start = -1
+    i = 0
+    while i < len(text):
+        c = text[i]
+        if in_str:
+            if c == "\\" and i + 1 < len(text):
+                i += 2
+                continue
+            if c == in_str:
+                in_str = None
+        elif c == '"':
+            in_str = c
+        elif c == "{":
+            if depth == 0:
+                start = i
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0 and start != -1:
+                candidate = text[start:i + 1]
+                try:
+                    return json.loads(candidate)
+                except json.JSONDecodeError:
+                    start = -1
+        i += 1
+    return None
+
+
+def call_llm(client, system_prompt: str, user_text: str) -> tuple[dict, dict]:
+    # Streaming is required because the Anthropic SDK refuses non-streaming
+    # requests that may exceed 10 minutes of generation time, which a 32K
+    # max_tokens polish on the full flags page reliably hits.
+    text_parts: list[str] = []
+    chars = 0
+    print("  streaming response", end="", flush=True)
+    with client.messages.stream(
+        model=MODEL,
+        max_tokens=MAX_TOKENS,
+        system=[{"type": "text", "text": system_prompt,
+                 "cache_control": {"type": "ephemeral"}}],
+        messages=[{"role": "user", "content": user_text}],
+    ) as stream:
+        for chunk in stream.text_stream:
+            text_parts.append(chunk)
+            chars += len(chunk)
+            if chars % 4000 < len(chunk):  # roughly one dot per 4K chars
+                print(".", end="", flush=True)
+        response = stream.get_final_message()
+    print(f" done ({chars} chars streamed)")
+    text = "".join(text_parts).strip()
+    if not text:
+        # Streaming should always yield text; if not, fall back to scanning
+        # the assembled message's content blocks just in case.
+        for block in response.content:
+            block_type = getattr(block, "type", None) or block.get("type")
+            if block_type == "text":
+                text += getattr(block, "text", "") or block.get("text", "")
+        text = text.strip()
+    if not text:
+        raise RuntimeError(
+            f"LLM returned no text content "
+            f"(stop_reason={response.stop_reason}, "
+            f"blocks={[getattr(b, 'type', None) for b in response.content]})"
+        )
+    parsed = _extract_json_object(text)
+    if parsed is None:
+        debug = SOURCE_DIR.parent / "llm_debug" / f"flags_polish_{datetime.now(timezone.utc):%Y%m%dT%H%M%SZ}.txt"
+        debug.parent.mkdir(parents=True, exist_ok=True)
+        debug.write_text(text, encoding="utf-8")
+        raise RuntimeError(
+            f"LLM response did not contain a parseable JSON object; "
+            f"raw text saved to {debug.relative_to(REPO_ROOT)} for inspection. "
+            f"stop_reason={response.stop_reason}, len={len(text)} chars."
+        )
+    usage = {
+        "input_tokens": response.usage.input_tokens,
+        "output_tokens": response.usage.output_tokens,
+        "stop_reason": response.stop_reason,
+    }
+    return parsed, usage
+
+
+def build_polish_user_text(
+    page_text: str,
+    ground_truth: dict[str, dict],
+    source_facts: dict[str, dict],
+    must_be_present: list[str],
+    flags_to_add: list[str],
+    enum_defaults_to_expand: list[dict],
+) -> str:
+    parts = [
+        "=== must_be_present ===",
+        "(closed-world set — output MUST have exactly these "
+        f"`### `--<name>`` sections, no others, no duplicates; "
+        f"{len(must_be_present)} flag(s))",
+        json.dumps(must_be_present, indent=2),
+        "",
+        "=== ground_truth ===",
+        json.dumps(ground_truth, indent=2, sort_keys=True, ensure_ascii=False),
+        "",
+        "=== source_facts ===",
+        json.dumps(source_facts, indent=2, sort_keys=True, ensure_ascii=False),
+        "",
+        "=== flags_to_add ===",
+        json.dumps(flags_to_add, indent=2),
+        "",
+        "=== enum_defaults_to_expand ===",
+        json.dumps(enum_defaults_to_expand, indent=2),
+        "",
+        "=== current page ===",
+        page_text,
+        "",
+        "=== task ===",
+        "Produce the JSON {markdown, notes}. JSON only.",
+    ]
+    return "\n".join(parts)
+
+
+# --- Validation --------------------------------------------------------------
+
+def repair_stub_sections(
+    polished: str, original: str,
+) -> tuple[str, list[str]]:
+    """Detect "stub" flag sections in `polished` (no `default:` line, often
+    bodies like "Duplicate removed — see above" or "Intentionally omitted")
+    and substitute the corresponding section from `original` if it has one.
+
+    This guards against an LLM failure mode where the model self-polices
+    against duplicates by replacing a real section with a stub, even though
+    no actual duplicate exists.
+    """
+    polished_secs = parse_sections(polished)
+    original_secs = parse_sections(original)
+
+    candidates: list[tuple[str, tuple[int, int]]] = [
+        (name, polished_secs[name].span)
+        for name in polished_secs
+        if polished_secs[name].default is None and name in original_secs
+        and original_secs[name].default is not None
+    ]
+    candidates.sort(key=lambda x: -x[1][0])  # process highest position first
+
+    text = polished
+    repaired: list[str] = []
+    for name, (s, e) in candidates:
+        orig_s, orig_e = original_secs[name].span
+        text = text[:s] + original[orig_s:orig_e] + text[e:]
+        repaired.append(name)
+    return text, repaired
+
+
+_LENIENT_HEADER_RE = re.compile(
+    r"^###[ \t]+`--(?P<name>[a-z][a-z0-9_]*)`[^\n]*\n",
+    re.MULTILINE,
+)
+
+
+def deduplicate_sections(text: str) -> tuple[str, list[str]]:
+    """Remove duplicate `### `--<name>`` sections, keeping the longest one
+    (richest content). Returns (deduped_text, dropped_flag_names).
+
+    Uses a lenient header regex that matches even when the LLM adds trailing
+    text on the header line (e.g. `### `--foo` is defined above.`) — those
+    stubs would otherwise hide from the strict SECTION_RE.
+    """
+    headers = list(_LENIENT_HEADER_RE.finditer(text))
+    if not headers:
+        return text, []
+    grouped: dict[str, list[tuple[int, int]]] = {}
+    for i, m in enumerate(headers):
+        end = headers[i + 1].start() if i + 1 < len(headers) else len(text)
+        grouped.setdefault(m.group("name"), []).append((m.start(), end))
+    drop_spans: list[tuple[int, int]] = []
+    dropped: list[str] = []
+    for name, spans in grouped.items():
+        if len(spans) <= 1:
+            continue
+        # Keep the longest section; on tie, the earliest in the file.
+        keep_idx = max(range(len(spans)),
+                       key=lambda i: (spans[i][1] - spans[i][0], -spans[i][0]))
+        for i, (s, e) in enumerate(spans):
+            if i != keep_idx:
+                drop_spans.append((s, e))
+                dropped.append(name)
+    drop_spans.sort(reverse=True)
+    out = text
+    for s, e in drop_spans:
+        out = out[:s] + out[e:]
+    return out, dropped
+
+
+def restore_missing_sections(
+    polished: str, original: str, must_be_present: set[str],
+) -> tuple[str, list[str]]:
+    """If a flag is in `must_be_present` AND was a real section in `original`
+    (with a `default:` line) but is missing from `polished`, paste the
+    original section into `polished` at a position close to where it lived
+    in `original` (right after the closest preceding flag that is in both)."""
+    polished_secs = parse_sections(polished)
+    original_secs = parse_sections(original)
+
+    missing = sorted(
+        n for n in must_be_present
+        if n in original_secs and original_secs[n].default is not None
+        and n not in polished_secs
+    )
+    if not missing:
+        return polished, []
+
+    original_order = sorted(original_secs.keys(),
+                            key=lambda n: original_secs[n].span[0])
+    text = polished
+    restored: list[str] = []
+    for name in missing:
+        s_orig, e_orig = original_secs[name].span
+        section_text = original[s_orig:e_orig]
+        # Find the closest preceding flag in original that is also currently
+        # in `text`, and append after it.
+        idx = original_order.index(name)
+        anchor: str | None = None
+        for j in range(idx - 1, -1, -1):
+            if original_order[j] in parse_sections(text):
+                anchor = original_order[j]
+                break
+        current = parse_sections(text)
+        if anchor and anchor in current:
+            anchor_s, anchor_e = current[anchor].span
+            text = text[:anchor_e] + section_text + text[anchor_e:]
+        else:
+            first_h3 = _LENIENT_HEADER_RE.search(text)
+            if first_h3:
+                text = text[:first_h3.start()] + section_text + text[first_h3.start():]
+            else:
+                # No H3 anywhere — append at end (degenerate case).
+                text = text.rstrip() + "\n\n" + section_text
+        restored.append(name)
+    return text, restored
+
+
+def validate_polish(
+    polished: str,
+    all_server_flags: dict[str, dict],
+    must_be_present: set[str],
+    enum_default_keep_int: dict[str, str],   # name -> integer that must stay in `default:`
+) -> list[str]:
+    errors: list[str] = []
+    # Duplicate-section detection has to run on the raw text — parse_sections
+    # collapses duplicates (last one wins) so it cannot tell us by itself.
+    head_counts: dict[str, int] = {}
+    for n in re.findall(r"^###\s+`--([a-z][a-z0-9_]*)`", polished, re.MULTILINE):
+        head_counts[n] = head_counts.get(n, 0) + 1
+    dupes = sorted(n for n, c in head_counts.items() if c > 1)
+    if dupes:
+        errors.append(f"duplicate flag section(s): {dupes[:10]}"
+                      f"{'...' if len(dupes) > 10 else ''}")
+    found = parse_sections(polished)
+    found_names = set(found.keys())
+
+    missing = must_be_present - found_names
+    if missing:
+        errors.append(f"missing {len(missing)} flag(s) from output: "
+                      f"{sorted(missing)[:10]}{'...' if len(missing) > 10 else ''}")
+
+    unexpected = found_names - must_be_present
+    if unexpected:
+        errors.append(f"unexpected flag(s) added: "
+                      f"{sorted(unexpected)[:10]}"
+                      f"{'...' if len(unexpected) > 10 else ''}")
+
+    for name, sec in sorted(found.items()):
+        if name in enum_default_keep_int:
+            expected = enum_default_keep_int[name]
+            got = sec.default or ""
+            if got.strip() != expected.strip():
+                errors.append(
+                    f"--{name}: enum-typed default should remain `{expected}` "
+                    f"(integer), got `{got}`"
+                )
+            continue
+        if name not in all_server_flags:
+            continue
+        truth = all_server_flags[name].get("default", "")
+        got = sec.default or ""
+        if not values_equivalent(got, truth):
+            errors.append(f"--{name}: default `{got}` != server `{truth}`")
+    return errors
+
+
+# --- Reporting ---------------------------------------------------------------
+
+def print_report(
+    raw_count: int,
+    user_count: int,
+    excluded_examples: list[str],
+    mech: MechResult,
+    polish_changed_flags: list[str] | None,
+    polish_validation_errors: list[str],
+    polish_skipped_reason: str | None,
+    polish_notes: list[str],
+    dry_run: bool,
+) -> int:
+    print("")
+    print("Ground truth:")
+    print(f"  total server flags ({{--helpfull}}):  {raw_count}")
+    print(f"  user-facing (Dragonfly):            {user_count}")
+    excluded_n = raw_count - user_count
+    sample = ", ".join(f"--{n}" for n in excluded_examples[:5])
+    print(f"  upstream/library (excluded):        {excluded_n}"
+          f" — e.g. {sample}{', ...' if len(excluded_examples) > 5 else ''}")
+    print(f"  (these are glog/absl logging & arg-plumbing flags;")
+    print(f"   they are statically linked but are not Dragonfly's documented surface)")
+
+    print("")
+    print("Mechanical pass:")
+    print(f"  default values fixed:        {len(mech.fixed_defaults)}")
+    print(f"  enum-typed deferred to LLM:  {len(mech.deferred_enum)}")
+    print(f"  default-fix failures:        {len(mech.failed_defaults)}")
+    print(f"  obsolete sections removed:   {len(mech.removed_from_doc)}")
+    print(f"  flags missing from doc:      {len(mech.missing_from_doc)}")
+
+    if mech.fixed_defaults:
+        print("\n=== Defaults updated mechanically ===")
+        for name, old, new in mech.fixed_defaults:
+            print(f"  --{name}: `{old}` → `{new}`")
+
+    if mech.deferred_enum:
+        print("\n=== Enum-typed defaults deferred to LLM polish ===")
+        print("  (kept as integer in `default:`; LLM expands description "
+              "with the value table)")
+        for name, doc, server in mech.deferred_enum:
+            print(f"  --{name}: doc=`{doc}` server=`{server}`")
+
+    if polish_skipped_reason:
+        print(f"\nLLM polish: skipped ({polish_skipped_reason})")
+    elif polish_validation_errors:
+        print(f"\nLLM polish: VALIDATION FAILED — output discarded")
+        for e in polish_validation_errors[:20]:
+            print(f"  ✗ {e}")
+        if len(polish_validation_errors) > 20:
+            print(f"  ... ({len(polish_validation_errors) - 20} more)")
+    else:
+        print(f"\nLLM polish: applied")
+        if polish_changed_flags:
+            print(f"  refreshed {len(polish_changed_flags)} flag section(s)")
+        for n in polish_notes[:10]:
+            print(f"  note: {n}")
+
+    failed = 0
+
+    if mech.failed_defaults:
+        failed = 1
+        print(f"\n=== Default-fix FAILURES ({len(mech.failed_defaults)}) ===")
+        for name, reason in mech.failed_defaults:
+            print(f"  --{name}: {reason}")
+
+    if mech.removed_from_doc:
+        print(f"\n=== Removed obsolete flag sections "
+              f"({len(mech.removed_from_doc)}) — server no longer reports these ===")
+        for n in mech.removed_from_doc:
+            print(f"  --{n}")
+
+    if mech.missing_from_doc and (polish_skipped_reason or polish_validation_errors):
+        failed = 1
+        print(f"\n=== Flags missing from doc, NOT added "
+              f"({len(mech.missing_from_doc)}) — re-run with LLM polish ===")
+        for n in mech.missing_from_doc[:30]:
+            print(f"  --{n}")
+        if len(mech.missing_from_doc) > 30:
+            print(f"  ... ({len(mech.missing_from_doc) - 30} more)")
+
+    if dry_run:
+        print("\n(dry-run — no files written)")
+    return failed
+
+
+# --- Main --------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--tag", help="Dragonfly tag (e.g. v1.38.0).")
+    g.add_argument("--facts", type=Path,
+                   help="Pre-captured facts JSON (skips Docker).")
+    ap.add_argument("--skip-pull", action="store_true",
+                    help="Skip docker pull when capturing facts.")
+    ap.add_argument("--refresh-facts", action="store_true",
+                    help="Re-capture facts even if cached.")
+    ap.add_argument("--refresh-source", action="store_true",
+                    help="Re-fetch & re-parse source even if cached.")
+    ap.add_argument("--skip-source", action="store_true",
+                    help="Skip C++ source parsing (LLM gets --helpfull only).")
+    ap.add_argument("--dry-run", action="store_true",
+                    help="Print everything without writing the page.")
+    ap.add_argument("--no-llm", action="store_true",
+                    help="Skip LLM polish step (mechanical pass only).")
+    args = ap.parse_args()
+
+    if args.facts and not args.skip_source:
+        # We need a tag to fetch source. If --facts is used without --tag,
+        # try to read tag from the facts file.
+        try:
+            facts_preview = json.loads(args.facts.read_text(encoding="utf-8"))
+            args.tag = facts_preview.get("tag")
+        except Exception:
+            args.tag = None
+        if not args.tag:
+            print("warning: --facts without --tag and tag not in facts file; "
+                  "skipping source capture")
+            args.skip_source = True
+
+    if not FLAGS_PAGE.exists():
+        ap.error(f"flags page not found: {FLAGS_PAGE}")
+
+    facts = load_facts(args)
+    all_server_flags = facts["data"]["flags"]
+    user_facing_flags = filter_user_facing(all_server_flags)
+    excluded = sorted(set(all_server_flags) - set(user_facing_flags))
+
+    page_text = FLAGS_PAGE.read_text(encoding="utf-8")
+    mech_text, mech = mechanical_pass(page_text, all_server_flags, user_facing_flags)
+
+    polish_skipped_reason: str | None = None
+    polish_validation_errors: list[str] = []
+    polish_changed_flags: list[str] | None = None
+    polish_notes: list[str] = []
+    final_text = mech_text
+
+    will_run_llm = (
+        not args.no_llm
+        and bool(os.getenv("ANTHROPIC_API_KEY"))
+        and (mech.missing_from_doc or mech.removed_from_doc
+             or mech.fixed_defaults or mech.deferred_enum)
+    )
+
+    if args.no_llm:
+        polish_skipped_reason = "--no-llm"
+    elif not os.getenv("ANTHROPIC_API_KEY"):
+        polish_skipped_reason = "ANTHROPIC_API_KEY not set"
+    elif not (mech.missing_from_doc or mech.removed_from_doc
+              or mech.fixed_defaults or mech.deferred_enum):
+        polish_skipped_reason = "page already matches server, nothing to polish"
+
+    source_facts: dict[str, dict] = {}
+    if will_run_llm and not args.skip_source:
+        target = set(all_server_flags.keys())
+        try:
+            source_facts = load_or_capture_source(args, target)
+        except Exception as e:
+            print(f"  warning: source capture failed ({e}); "
+                  f"LLM will only have --helpfull data")
+            source_facts = {}
+
+    if will_run_llm:
+        try:
+            import anthropic
+        except ImportError:
+            polish_skipped_reason = "anthropic SDK not installed"
+        else:
+            print("\nCalling Claude for full-page polish...")
+            client = anthropic.Anthropic()
+            # Closed-world set: exactly the flags that should appear in the
+            # output. Existing in the page (mechanically reconciled) plus
+            # new user-facing ones to add. Upstream glog/absl flags that
+            # aren't already in the doc are excluded by construction.
+            must_be_present_set = (
+                set(parse_sections(mech_text).keys()) | set(mech.missing_from_doc)
+            )
+            must_be_present = sorted(must_be_present_set)
+            # Restrict ground_truth and source_facts to this set so the LLM
+            # can't be tempted to add upstream flags it sees in the dict.
+            gt_for_llm = {
+                n: all_server_flags[n] for n in must_be_present_set
+                if n in all_server_flags
+            }
+            sf_for_llm = {
+                n: source_facts[n] for n in must_be_present_set
+                if n in source_facts
+            }
+            enum_defaults_to_expand = [
+                {"flag": n, "doc_default": doc, "server_default": server}
+                for (n, doc, server) in mech.deferred_enum
+            ]
+            user_text = build_polish_user_text(
+                mech_text, gt_for_llm, sf_for_llm, must_be_present,
+                mech.missing_from_doc, enum_defaults_to_expand,
+            )
+            try:
+                parsed, usage = call_llm(client, POLISH_SYSTEM, user_text)
+            except Exception as e:
+                polish_skipped_reason = f"LLM call failed: {e}"
+            else:
+                print(f"  tokens: in={usage['input_tokens']} "
+                      f"out={usage['output_tokens']} stop={usage['stop_reason']}")
+                polished = parsed.get("markdown", "")
+                polish_notes = parsed.get("notes", []) or []
+                if not polished.strip():
+                    polish_validation_errors.append("LLM returned empty markdown")
+                else:
+                    polished, dropped = deduplicate_sections(polished)
+                    if dropped:
+                        polish_notes.append(
+                            f"auto-deduped {len(dropped)} duplicate section(s): "
+                            f"{sorted(set(dropped))}"
+                        )
+                    polished, repaired = repair_stub_sections(polished, mech_text)
+                    if repaired:
+                        polish_notes.append(
+                            f"auto-repaired {len(repaired)} stub section(s) "
+                            f"from input: {sorted(set(repaired))}"
+                        )
+                    polished, restored = restore_missing_sections(
+                        polished, mech_text, must_be_present_set,
+                    )
+                    if restored:
+                        polish_notes.append(
+                            f"auto-restored {len(restored)} missing section(s) "
+                            f"from input: {sorted(set(restored))}"
+                        )
+                    enum_keep_int = {n: doc for (n, doc, _) in mech.deferred_enum}
+                    polish_validation_errors = validate_polish(
+                        polished, all_server_flags, must_be_present_set, enum_keep_int,
+                    )
+                    if polish_validation_errors:
+                        # Save raw output so the user can inspect it.
+                        debug = SOURCE_DIR.parent / "llm_debug" / f"flags_polish_validation_failed_{datetime.now(timezone.utc):%Y%m%dT%H%M%SZ}.md"
+                        debug.parent.mkdir(parents=True, exist_ok=True)
+                        debug.write_text(polished, encoding="utf-8")
+                        print(f"  raw LLM output saved to "
+                              f"{debug.relative_to(REPO_ROOT)} for inspection")
+                    if not polish_validation_errors:
+                        final_text = polished
+                        polish_changed_flags = sorted(
+                            set(mech.missing_from_doc)
+                            | {n for n, _, _ in mech.fixed_defaults}
+                            | {n for n, _, _ in mech.deferred_enum}
+                        )
+
+    if not args.dry_run:
+        FLAGS_PAGE.write_text(final_text, encoding="utf-8")
+
+    return print_report(
+        raw_count=len(all_server_flags),
+        user_count=len(user_facing_flags),
+        excluded_examples=excluded,
+        mech=mech,
+        polish_changed_flags=polish_changed_flags,
+        polish_validation_errors=polish_validation_errors,
+        polish_skipped_reason=polish_skipped_reason,
+        polish_notes=polish_notes,
+        dry_run=args.dry_run,
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/docsync/propose_change_message.py
+++ b/tools/docsync/propose_change_message.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""propose_change_message.py — Suggest a commit/PR title + description for
+the current working-tree changes.
+
+Reads the git diff (working tree by default, or staged / against a base ref),
+including untracked files, and asks Claude for a tight conventional-commit
+title plus a Markdown body suitable for both `git commit -m` and
+`gh pr create --body`.
+
+The tool **never** runs git or gh commands itself. It writes the proposed
+message to `tools/generated/change_messages/<timestamp>.md` and prints it
+to stdout.
+
+Usage:
+    python tools/docsync/propose_change_message.py
+    python tools/docsync/propose_change_message.py --staged
+    python tools/docsync/propose_change_message.py --base origin/main
+    python tools/docsync/propose_change_message.py --dump-prompt
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import anthropic
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MESSAGES_DIR = REPO_ROOT / "tools" / "generated" / "change_messages"
+
+MODEL = "claude-sonnet-4-6"
+MAX_TOKENS = 1500
+DIFF_BUDGET = 60_000  # rough char cap on the diff sent to the model
+
+
+# --- Git helpers -------------------------------------------------------------
+
+def run_git(args: list[str], check: bool = True) -> subprocess.CompletedProcess:
+    return subprocess.run(["git"] + args, cwd=REPO_ROOT,
+                          capture_output=True, text=True, check=check)
+
+
+def diff_text(scope: str, base: str | None) -> tuple[str, list[str]]:
+    """Return (diff_text, changed_paths). For working-tree scope this also
+    appends untracked files to `changed_paths` (with a synthetic /dev/null
+    diff in `diff_text`) so newly-created pages aren't invisible to the
+    message writer."""
+    if base:
+        diff_args = ["diff", f"{base}...HEAD"]
+        files_args = ["diff", "--name-only", f"{base}...HEAD"]
+    elif scope == "staged":
+        diff_args = ["diff", "--cached"]
+        files_args = ["diff", "--cached", "--name-only"]
+    else:  # working tree (staged + unstaged)
+        diff_args = ["diff", "HEAD"]
+        files_args = ["diff", "HEAD", "--name-only"]
+    diff = run_git(diff_args, check=False).stdout
+    files = [l for l in run_git(files_args, check=False).stdout.splitlines() if l]
+
+    if not base and scope != "staged":
+        untracked = [
+            l for l in run_git(
+                ["ls-files", "--others", "--exclude-standard"], check=False,
+            ).stdout.splitlines() if l
+        ]
+        for u in untracked:
+            if u in files:
+                continue
+            files.append(u)
+            try:
+                content = (REPO_ROOT / u).read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                content = "(binary or unreadable)"
+            diff += (
+                f"\ndiff --git a/{u} b/{u}\nnew file\n--- /dev/null\n+++ b/{u}\n"
+                + "".join(f"+{ln}\n" for ln in content.splitlines())
+            )
+    return diff, files
+
+
+def status_lines() -> list[str]:
+    return [l for l in run_git(["status", "--short"]).stdout.splitlines() if l]
+
+
+def stat_summary(scope: str, base: str | None) -> str:
+    if base:
+        args = ["diff", "--stat", f"{base}...HEAD"]
+    elif scope == "staged":
+        args = ["diff", "--cached", "--stat"]
+    else:
+        args = ["diff", "HEAD", "--stat"]
+    return run_git(args, check=False).stdout
+
+
+def categorize(files: list[str]) -> dict[str, list[str]]:
+    """Bucket changed files for an at-a-glance summary in the prompt."""
+    buckets = {
+        "command_ref":   [],
+        "managing":      [],
+        "other_docs":    [],
+        "tooling":       [],
+        "other":         [],
+    }
+    for f in files:
+        if f.startswith("docs/command-reference/"):
+            buckets["command_ref"].append(f)
+        elif f.startswith("docs/managing-dragonfly/"):
+            buckets["managing"].append(f)
+        elif f.startswith("docs/"):
+            buckets["other_docs"].append(f)
+        elif f.startswith("tools/"):
+            buckets["tooling"].append(f)
+        else:
+            buckets["other"].append(f)
+    return buckets
+
+
+# --- Prompt construction -----------------------------------------------------
+
+WRITER_SYSTEM = """\
+You write commit messages and PR descriptions for documentation changes in
+the Dragonfly DB docs repo.
+
+Output format — strict JSON only:
+
+  {
+    "title": "<conventional-commit subject, <=70 chars>",
+    "body":  "<Markdown body with ## Summary and ## Test plan sections>"
+  }
+
+Hard constraints:
+- Title in conventional-commits style: `docs: fix ACL ...`, `docs: update flag defaults`, etc.
+- No leading articles ("the", "a"), no period at the end, lowercase after `docs:`.
+- Body: ## Summary (1–3 bullets) and ## Test plan (markdown checklist).
+- Don't speculate beyond what the diff justifies.
+- Don't promise features that aren't in the diff.
+- No emojis, no co-author trailers, no boilerplate.
+- If multiple unrelated change types are mixed, mention each briefly.
+- Output JSON only — no prose before or after.
+"""
+
+
+def build_user_text(
+    diff: str, status: list[str], stats: str,
+    buckets: dict[str, list[str]],
+) -> str:
+    parts: list[str] = []
+    parts.append("=== git status (--short) ===")
+    parts.append("\n".join(status) or "(clean)")
+    parts.append("")
+    parts.append("=== diff --stat ===")
+    parts.append(stats.strip() or "(no diff)")
+    parts.append("")
+    if any(buckets.values()):
+        parts.append("=== Files by bucket ===")
+        for k, fs in buckets.items():
+            if fs:
+                parts.append(f"{k} ({len(fs)}):")
+                parts.extend(f"  {f}" for f in fs)
+        parts.append("")
+    parts.append("=== Diff ===")
+    if len(diff) > DIFF_BUDGET:
+        parts.append(diff[:DIFF_BUDGET])
+        parts.append(f"\n…(diff truncated at {DIFF_BUDGET:,} chars; "
+                     f"original {len(diff):,} chars)…")
+    else:
+        parts.append(diff)
+    parts.append("")
+    parts.append("=== Task ===")
+    parts.append("Produce the JSON {title, body} now. Output JSON only.")
+    return "\n".join(parts)
+
+
+def call_llm(client: anthropic.Anthropic, user_text: str) -> tuple[dict, dict]:
+    response = client.messages.create(
+        model=MODEL,
+        max_tokens=MAX_TOKENS,
+        system=[{"type": "text", "text": WRITER_SYSTEM,
+                 "cache_control": {"type": "ephemeral"}}],
+        messages=[{"role": "user", "content": user_text}],
+    )
+    text = response.content[0].text.strip()
+    if text.startswith("```"):
+        text = text.split("\n", 1)[1] if "\n" in text else text
+        text = text.rsplit("```", 1)[0]
+    parsed = json.loads(text)
+    usage = {
+        "input_tokens": response.usage.input_tokens,
+        "output_tokens": response.usage.output_tokens,
+        "stop_reason": response.stop_reason,
+    }
+    return parsed, usage
+
+
+# --- Atomic write ------------------------------------------------------------
+
+def write_atomic(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(content, encoding="utf-8")
+    os.replace(tmp, path)
+
+
+# --- Main --------------------------------------------------------------------
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    g = ap.add_mutually_exclusive_group()
+    g.add_argument("--staged", action="store_true",
+                   help="Describe only --cached (staged) diff.")
+    g.add_argument("--base", help="Describe diff <base>...HEAD (e.g. origin/main).")
+    ap.add_argument("--dump-prompt", action="store_true",
+                    help="Write the prompt and exit without calling the LLM.")
+    args = ap.parse_args()
+
+    scope = "staged" if args.staged else "worktree"
+    diff, files = diff_text(scope, args.base)
+    if not files and not diff.strip():
+        print("Nothing to describe (empty diff).")
+        return 0
+
+    status = status_lines()
+    stats = stat_summary(scope, args.base)
+    buckets = categorize(files)
+
+    user_text = build_user_text(diff, status, stats, buckets)
+
+    if args.dump_prompt:
+        prompt_path = MESSAGES_DIR / "_last.prompt.md"
+        write_atomic(
+            prompt_path,
+            f"=== SYSTEM ===\n{WRITER_SYSTEM}\n\n=== USER ===\n{user_text}\n",
+        )
+        print(f"Wrote prompt: {prompt_path.relative_to(REPO_ROOT)}")
+        return 0
+
+    print(f"Files in scope: {len(files)}")
+    print("Calling Claude...")
+    client = anthropic.Anthropic()
+    msg, usage = call_llm(client, user_text)
+    print(f"  tokens: in={usage['input_tokens']} out={usage['output_tokens']} "
+          f"stop={usage['stop_reason']}")
+
+    title = msg.get("title", "").strip()
+    body = msg.get("body", "").strip()
+    rendered = f"{title}\n\n{body}\n"
+    ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out_path = MESSAGES_DIR / f"{ts}.md"
+    write_atomic(out_path, rendered)
+
+    print("\n" + "=" * 70)
+    print(f"# Title:\n{title}")
+    print("\n# Body:")
+    print(body)
+    print("=" * 70)
+    print(f"\nSaved to {out_path.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/docsync/requirements.txt
+++ b/tools/docsync/requirements.txt
@@ -1,0 +1,2 @@
+redis>=5.0
+anthropic>=0.40.0


### PR DESCRIPTION
## Summary

- Adds `tools/docsync/` with five production scripts (`acl_sync.py`, `flags_sync.py`, `docs_sync.py`, `dfly_facts.py`, `propose_change_message.py`) that keep `docs/` in sync with a live Dragonfly server by capturing ground truth from a Docker image and optionally the C++ source
- Each script applies minimal-diff mechanical edits first, then falls back to an LLM (Claude) repair/polish pass with structural validation and Docker-verified examples; raw LLM output is preserved under `tools/generated/llm_debug/` on failure
- Updates `.gitignore` to exclude `tools/generated/` artifacts and `__pycache__`
