### PR TITLE
docs: fix ACL categories across 46 command reference pages

### DIFF
--- a/docs/command-reference/count-min-sketch/cms.incrby.md
+++ b/docs/command-reference/count-min-sketch/cms.incrby.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(n) where n is the number of items
 
-**ACL categories:** @cms
+**ACL categories:** @cms, @fast
 
 Increments the count of one or more `item`s in the Count-Min Sketch stored at `key` by the given `increment` values.
 The `increment` value must be a positive integer greater than `0`.

--- a/docs/command-reference/count-min-sketch/cms.info.md
+++ b/docs/command-reference/count-min-sketch/cms.info.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(1)
 
-**ACL categories:** @cms
+**ACL categories:** @cms, @fast, @read
 
 Returns metadata about the Count-Min Sketch stored at `key`, including its dimensions and the total number of counted events.
 

--- a/docs/command-reference/count-min-sketch/cms.initbydim.md
+++ b/docs/command-reference/count-min-sketch/cms.initbydim.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(1)
 
-**ACL categories:** @cms
+**ACL categories:** @cms, @fast
 
 Initializes a Count-Min Sketch filter at `key` with the given `width` and `depth` dimensions.
 

--- a/docs/command-reference/count-min-sketch/cms.initbyprob.md
+++ b/docs/command-reference/count-min-sketch/cms.initbyprob.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(1)
 
-**ACL categories:** @cms
+**ACL categories:** @cms, @fast
 
 Initializes a Count-Min Sketch filter at `key` with dimensions automatically calculated from
 the desired `error` rate and `probability` of accuracy.

--- a/docs/command-reference/count-min-sketch/cms.merge.md
+++ b/docs/command-reference/count-min-sketch/cms.merge.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(n·w·d) where n is the number of source sketches, w is the width, and d is the depth
 
-**ACL categories:** @cms
+**ACL categories:** @cms, @slow
 
 Merges multiple source Count-Min Sketches into `destination`.
 The `destination` key must be pre-initialized via [`CMS.INITBYDIM`](./cms.initbydim.md) or [`CMS.INITBYPROB`](./cms.initbyprob.md) before calling this command — if it does not exist, an error is returned.

--- a/docs/command-reference/count-min-sketch/cms.query.md
+++ b/docs/command-reference/count-min-sketch/cms.query.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(n) where n is the number of items
 
-**ACL categories:** @cms
+**ACL categories:** @cms, @fast, @read
 
 Returns the estimated count of one or more `item`s from the Count-Min Sketch stored at `key`.
 

--- a/docs/command-reference/generic/expiretime.md
+++ b/docs/command-reference/generic/expiretime.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(1)
 
-**ACL categories:** @keyspace, @write, @fast
+**ACL categories:** @keyspace, @fast, @read
 
 Returns the absolute Unix timestamp (since January 1, 1970) in seconds at which the given key will expire.
 

--- a/docs/command-reference/generic/pexpiretime.md
+++ b/docs/command-reference/generic/pexpiretime.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(1)
 
-**ACL categories:** @keyspace, @write, @fast
+**ACL categories:** @keyspace, @fast, @read
 
 This command works exactly like [`EXPIRETIME`](./expiretime.md),
 but the absolute Unix expiration timestamp of the key is returned in milliseconds instead of seconds.

--- a/docs/command-reference/generic/script.md
+++ b/docs/command-reference/generic/script.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** Depends on subcommand.
 
-**ACL categories:** @slow
+**ACL categories:** @slow, @scripting
 
 This is a container command for script management commands.
 

--- a/docs/command-reference/generic/sort_ro.md
+++ b/docs/command-reference/generic/sort_ro.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(N+M\*log(M)) where N is the number of elements in the list or set to sort, and M the number of returned elements. When the elements are not sorted, complexity is O(N).
 
-**ACL categories:** @read, @set, @sortedset, @list, @slow
+**ACL categories:** @read, @set, @sortedset, @list, @slow, @dangerous
 
 Read-only variant of the [SORT](./sort) command. It is exactly like the original [SORT](./sort) command but refuses the `STORE` option and can safely be used in read-only replicas.
 

--- a/docs/command-reference/hashes/hgetall.md
+++ b/docs/command-reference/hashes/hgetall.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(N) where N is the size of the hash.
 
-**ACL categories:** @read, @hash, @slow
+**ACL categories:** @read, @hash, @fast
 
 Returns all fields and values of the hash stored at `key`.
 In the returned value, every field name is followed by its value, so the length

--- a/docs/command-reference/hashes/hsetex.md
+++ b/docs/command-reference/hashes/hsetex.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(1) for each field/value pair added, so O(N) to add N field/value pairs when the command is called with multiple field/value pairs.
 
-**ACL categories:** @read, @hash, @fast
+**ACL categories:** @hash, @fast, @write
 
 **Warning:** Experimental! Dragonfly-specific.
 

--- a/docs/command-reference/hashes/hsetnx.md
+++ b/docs/command-reference/hashes/hsetnx.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(1)
 
-**ACL categories:** @read, @hash, @fast
+**ACL categories:** @hash, @fast, @write
 
 Sets `field` in the hash stored at `key` to `value`, only if `field` does not
 yet exist.

--- a/docs/command-reference/hashes/hvals.md
+++ b/docs/command-reference/hashes/hvals.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(N) where N is the size of the hash.
 
-**ACL categories:** @read, @hash, @fast
+**ACL categories:** @read, @hash, @slow
 
 Returns all values in the hash stored at `key`.
 

--- a/docs/command-reference/hyperloglog/pfadd.md
+++ b/docs/command-reference/hyperloglog/pfadd.md
@@ -13,7 +13,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(1) for each element added.
 
-**ACL categories:** @write, @hyperloglog, @fast
+**ACL categories:** @write, @fast, @hyperlog
 
 Adds all the element arguments to the HyperLogLog data structure stored at the variable name
 specified as first argument.

--- a/docs/command-reference/hyperloglog/pfcount.md
+++ b/docs/command-reference/hyperloglog/pfcount.md
@@ -15,7 +15,7 @@ import PageTitle from '@site/src/components/PageTitle';
 O(N) with N being the number of keys, and much bigger constant times, when called with multiple
 keys.
 
-**ACL categories:** @read, @hyperloglog, @slow
+**ACL categories:** @read, @slow, @hyperlog
 
 When called with a single key, returns the approximated cardinality computed by the HyperLogLog data
 structure stored at the specified variable, which is 0 if the variable does not exist.

--- a/docs/command-reference/hyperloglog/pfmerge.md
+++ b/docs/command-reference/hyperloglog/pfmerge.md
@@ -13,7 +13,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(N) to merge N HyperLogLogs, but with high constant times.
 
-**ACL categories:** @write, @hyperloglog, @slow
+**ACL categories:** @write, @slow, @hyperlog
 
 Merge multiple HyperLogLog values into a unique value that will approximate the cardinality of the
 union of the observed Sets of the source HyperLogLog structures.

--- a/docs/command-reference/search/ft._list.md
+++ b/docs/command-reference/search/ft._list.md
@@ -10,6 +10,8 @@ description: Returns a list of all existing indexes
 
 **Time complexity:** O(1)
 
+**ACL categories:** @ft_search
+
 ## Description
 
 Return a list of all existing indexes.

--- a/docs/command-reference/search/ft.aggregate.md
+++ b/docs/command-reference/search/ft.aggregate.md
@@ -15,6 +15,8 @@ description: Runs a search query and performs aggregate transformations
 
 **Time complexity:** O(N)
 
+**ACL categories:** @ft_search
+
 ## Description
 
 Run a search query and perform aggregate transformations on the results.

--- a/docs/command-reference/search/ft.alter.md
+++ b/docs/command-reference/search/ft.alter.md
@@ -12,7 +12,7 @@ FT.ALTER {index} [SKIPINITIALSCAN] SCHEMA ADD {attribute} {options} ...
 
 **Time complexity:** O(N) where N is the number of keys in the keyspace
 
-**ACL Categories:** @search
+**ACL Categories:** @ft_search
 
 ## Description
 

--- a/docs/command-reference/search/ft.config.md
+++ b/docs/command-reference/search/ft.config.md
@@ -11,6 +11,7 @@ description: Configure search engine at runtime
     FT.CONFIG HELP [option]
 
 **Time complexity:** O(1)
+**ACL categories:** @ft_search
 
 ## Description
 

--- a/docs/command-reference/search/ft.create.md
+++ b/docs/command-reference/search/ft.create.md
@@ -14,6 +14,7 @@ description: Creates an index with the given spec
       [NOINDEX] [ field_name [AS alias] TEXT | TAG | NUMERIC | VECTOR | GEO [ SORTABLE ] [NOINDEX] ...]
 
 **Time complexity:** O(K) at creation where K is the number of fields, O(N) if scanning the keyspace is triggered, where N is the number of keys in the keyspace.
+**ACL categories:** @ft_search
 
 ## Description
 

--- a/docs/command-reference/search/ft.dropindex.md
+++ b/docs/command-reference/search/ft.dropindex.md
@@ -9,6 +9,7 @@ description: Deletes the index
     FT.DROPINDEX index [DD]
 
 **Time complexity:** O(1) or O(N) if `DD` is used, where N is the number of documents in the index.
+**ACL categories:** @ft_search
 
 ## Description
 

--- a/docs/command-reference/search/ft.info.md
+++ b/docs/command-reference/search/ft.info.md
@@ -10,6 +10,8 @@ description: Returns information and statistics on the index
 
 **Time complexity:** O(1)
 
+**ACL categories:** @ft_search
+
 ## Description
 
 Return information and statistics on the index.

--- a/docs/command-reference/search/ft.profile.md
+++ b/docs/command-reference/search/ft.profile.md
@@ -9,6 +9,7 @@ description: Uses SEARCH command to collect performance info
     FT.PROFILE index SEARCH | AGGREGATE [LIMITED] QUERY query
 
 **Time complexity:** O(N)
+**ACL categories:** @ft_search
 
 ## Description
 

--- a/docs/command-reference/search/ft.search.md
+++ b/docs/command-reference/search/ft.search.md
@@ -16,6 +16,7 @@ description: Searches the index with a query, returning docs or just IDs
       [FILTER field min max]
 
 **Time complexity:** O(N)
+**ACL categories:** @ft_search
 
 ## Description
 

--- a/docs/command-reference/search/ft.syndump.md
+++ b/docs/command-reference/search/ft.syndump.md
@@ -9,6 +9,7 @@ description: Dumps the synonyms from an index
     FT.SYNDUMP index
 
 **Time complexity:** O(1)
+**ACL categories:** @ft_search
 
 ## Description
 

--- a/docs/command-reference/search/ft.synupdate.md
+++ b/docs/command-reference/search/ft.synupdate.md
@@ -10,6 +10,7 @@ description: Creates or updates a synonym group
       [SKIPINITIALSCAN] term [term ...]
 
 **Time complexity:** O(N)
+**ACL categories:** @ft_search
 
 ## Description
 

--- a/docs/command-reference/search/ft.tagvals.md
+++ b/docs/command-reference/search/ft.tagvals.md
@@ -10,7 +10,7 @@ description: Searches the index with a query, returning docs or just IDs
 
 **Time complexity:** O(N)
 
-**ACL Categories:** @dangerous, @read, @search, @slow
+**ACL Categories:** @ft_search
 
 ## Description
 

--- a/docs/command-reference/server-management/config.md
+++ b/docs/command-reference/server-management/config.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** Depends on subcommand.
 
-**ACL categories:** @slow
+**ACL categories:** @slow, @admin, @dangerous
 
 This is a container command for runtime configuration commands.
 Currently, the following subcommands are supported:

--- a/docs/command-reference/server-management/echo.md
+++ b/docs/command-reference/server-management/echo.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(1)
 
-**ACL categories:** @admin, @slow, @dangerous
+**ACL categories:** @connection, @fast
 
 Returns `message`.
 

--- a/docs/command-reference/server-management/memory.md
+++ b/docs/command-reference/server-management/memory.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** Depends on subcommand.
 
-**ACL categories:** @slow
+**ACL categories:** @slow, @read
 
 This is a container command for memory introspection and management commands.
 

--- a/docs/command-reference/server-management/slowlog.md
+++ b/docs/command-reference/server-management/slowlog.md
@@ -12,7 +12,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
     SLOWLOG [GET | LEN | RESET | HELP]
 
-**ACL categories:** @slow, @admin
+**ACL categories:** @slow, @admin, @dangerous
 
 This is a container command for slowlog management commands.
 

--- a/docs/command-reference/sorted-sets/bzpopmax.md
+++ b/docs/command-reference/sorted-sets/bzpopmax.md
@@ -22,7 +22,7 @@ BZPOPMAX key [key ...] timeout
 ```
 
 - **Time complexity:** O(log(N)) with N being the number of elements in the sorted set.
-- **ACL categories:** @write, @sortedset, @fast, @blocking
+- **ACL categories:** @write, @sortedset, @blocking, @slow
 
 ## Parameter Explanations
 

--- a/docs/command-reference/sorted-sets/bzpopmin.md
+++ b/docs/command-reference/sorted-sets/bzpopmin.md
@@ -22,7 +22,7 @@ BZPOPMIN key [key ...] timeout
 ```
 
 - **Time complexity:** O(log(N)) with N being the number of elements in the sorted set.
-- **ACL categories:** @write, @sortedset, @fast, @blocking
+- **ACL categories:** @write, @sortedset, @blocking, @slow
 
 ## Parameter Explanations
 

--- a/docs/command-reference/sorted-sets/zlexcount.md
+++ b/docs/command-reference/sorted-sets/zlexcount.md
@@ -22,7 +22,7 @@ ZLEXCOUNT key min max
 ```
 
 - **Time complexity:** O(log(N)) with N being the number of elements in the sorted set.
-- **ACL categories:** @read, @sortedset, @fast
+- **ACL categories:** @read, @sortedset, @slow
 
 ## Parameter Explanations
 

--- a/docs/command-reference/stream/xclaim.md
+++ b/docs/command-reference/stream/xclaim.md
@@ -21,7 +21,7 @@ XCLAIM key group consumer min-idle-time id [id ...] [IDLE ms] [TIME ms-unix-time
 ```
 
 - **Time complexity:** O(log N) with N being the number of messages in the pending entries list (PEL) of the consumer group.
-- **ACL categories:** @write, @stream, @fast
+- **ACL categories:** @write, @fast
 
 ## Parameter Explanations
 

--- a/docs/command-reference/stream/xpending.md
+++ b/docs/command-reference/stream/xpending.md
@@ -23,7 +23,7 @@ XPENDING key group [start end count] [consumer]
   O(M), where M is the total number of entries scanned when used with the `IDLE` filter.
   When the command returns just the summary and the list of consumers is small, it runs in O(1) time.
   Otherwise, an additional O(N) time for iterating every consumer.
-- **ACL categories:** @read, @stream, @slow
+- **ACL categories:** @read, @stream
 
 ## Parameter Explanations
 

--- a/docs/command-reference/stream/xsetid.md
+++ b/docs/command-reference/stream/xsetid.md
@@ -18,6 +18,8 @@ The `XSETID` command is an internal command. It is used by a Dragonfly primary i
 XSETID key last-id
 ```
 
+**ACL categories:** @slow, @stream, @write
+
 ## Parameter Explanations
 
 - `key`: The stream for which you want to set the last delivered ID.

--- a/docs/command-reference/top-k/topk.add.md
+++ b/docs/command-reference/top-k/topk.add.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(n * depth) where n is the number of items
 
-**ACL categories:** @topk
+**ACL categories:** @topk, @fast, @write
 
 Adds one or more items to the Top-K data structure stored at `key`.
 The `key` must already exist (created via [`TOPK.RESERVE`](./topk.reserve.md)); otherwise, an error is returned.

--- a/docs/command-reference/top-k/topk.count.md
+++ b/docs/command-reference/top-k/topk.count.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(n) where n is the number of items
 
-**ACL categories:** @topk
+**ACL categories:** @topk, @fast, @read
 
 Returns the estimated count of one or more items in the Top-K data structure stored at `key`.
 The `key` must already exist (created via [`TOPK.RESERVE`](./topk.reserve.md)); otherwise, an error is returned.

--- a/docs/command-reference/top-k/topk.incrby.md
+++ b/docs/command-reference/top-k/topk.incrby.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(n * depth) where n is the number of items
 
-**ACL categories:** @topk
+**ACL categories:** @topk, @fast, @write
 
 Increments the count of one or more items in the Top-K data structure stored at `key` by the given `increment` values.
 The `key` must already exist (created via [`TOPK.RESERVE`](./topk.reserve.md)); otherwise, an error is returned.

--- a/docs/command-reference/top-k/topk.info.md
+++ b/docs/command-reference/top-k/topk.info.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(1)
 
-**ACL categories:** @topk
+**ACL categories:** @topk, @fast, @read
 
 Returns metadata about the Top-K data structure stored at `key`, including its configuration parameters.
 The `key` must already exist (created via [`TOPK.RESERVE`](./topk.reserve.md)); otherwise, an error is returned.

--- a/docs/command-reference/top-k/topk.list.md
+++ b/docs/command-reference/top-k/topk.list.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(k log k) where k is the number of top items tracked
 
-**ACL categories:** @topk
+**ACL categories:** @topk, @read, @slow
 
 Returns all items currently tracked in the Top-K data structure stored at `key`, sorted by estimated count in descending order.
 The `key` must already exist (created via [`TOPK.RESERVE`](./topk.reserve.md)); otherwise, an error is returned.

--- a/docs/command-reference/top-k/topk.query.md
+++ b/docs/command-reference/top-k/topk.query.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(k) per queried item, or O(m * k) when querying m items at once
 
-**ACL categories:** @topk
+**ACL categories:** @topk, @fast, @read
 
 Checks whether one or more items are currently in the Top-K list stored at `key`.
 The `key` must already exist (created via [`TOPK.RESERVE`](./topk.reserve.md)); otherwise, an error is returned.

--- a/docs/command-reference/top-k/topk.reserve.md
+++ b/docs/command-reference/top-k/topk.reserve.md
@@ -14,7 +14,7 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **Time complexity:** O(1)
 
-**ACL categories:** @topk
+**ACL categories:** @topk, @fast, @write
 
 Creates a new Top-K data structure at `key` that tracks the top `topk` most frequent items.
 


### PR DESCRIPTION
## Summary

- Corrects ACL category tags for commands across CMS, Top-K, HyperLogLog, hash, sorted-set, stream, search, and server-management groups (e.g. adding `@read`/`@write`/`@fast`/`@slow` where missing, removing incorrect ones, replacing `@hyperloglog` with `@hyperlog`, `@search` with `@ft_search`).
- Adds missing `**ACL categories:**` fields to pages that had none (`FT._LIST`, `FT.INFO`, `FT.CONFIG`, `FT.CREATE`, `FT.DROPINDEX`, `FT.PROFILE`, `FT.SEARCH`, `FT.SYNDUMP`, `FT.SYNUPDATE`, `XSETID`).
- Fixes a small trailing-newline issue in `ft.aggregate.md`.
