### PR TITLE
docs: update command refs, search docs, and managing guides

### DIFF
--- a/docs/command-reference/count-min-sketch/cms.initbyprob.md
+++ b/docs/command-reference/count-min-sketch/cms.initbyprob.md
@@ -19,9 +19,9 @@ import PageTitle from '@site/src/components/PageTitle';
 Initializes a Count-Min Sketch filter at `key` with dimensions automatically calculated from
 the desired `error` rate and `probability` of accuracy.
 
-- `error`: The desired error rate as a fraction of the total count. Must be a positive number between `0` and `1`.
+- `error`: The desired error rate as a fraction of the total count. Must be a positive number between `0` and `1` (exclusive).
   For example, `0.01` means the estimated count will be within `1%` of the true count.
-- `probability`: The desired failure probability — the probability that an estimate will exceed the error bounds. Must be a positive number between `0` and `1`.
+- `probability`: The desired failure probability — the probability that an estimate will exceed the error bounds. Must be a positive number between `0` and `1` (exclusive).
   For example, `0.01` means there is a `1%` chance the estimate exceeds the error bounds. Lower values produce a deeper sketch with fewer errors but higher memory and CPU usage.
 
 If `key` already exists, an error is returned.
@@ -36,7 +36,6 @@ If `key` already exists, an error is returned.
 dragonfly> CMS.INITBYPROB cms_key 0.01 0.01
 OK
 ```
-
 ## See also
 
 [`CMS.INITBYDIM`](./cms.initbydim.md) | [`CMS.INCRBY`](./cms.incrby.md) | [`CMS.QUERY`](./cms.query.md) | [`CMS.INFO`](./cms.info.md)

--- a/docs/command-reference/hashes/hsetex.md
+++ b/docs/command-reference/hashes/hsetex.md
@@ -32,14 +32,59 @@ The expiration time can be accessed with the [`FIELDTTL`](../generic/fieldttl.md
 
 ## Examples
 
+Cache a user session with a 30-second TTL on every field:
+
 ```shell
-dragonfly> HSETEX myhash 100 field1 Hello
-(integer) 1
-dragonfly> HGETALL myhash
-1) "field1"
-2) "Hello"
-dragonfly> HSETEX myhash 100 field1 Hello
-(integer) 0
-dragonfly> HSETEX myhash NX 100 field1 Hello
-(integer) 0
+dragonfly> HSETEX session:abc 30 user "alice" role "admin"
+(integer) 2
+dragonfly> HGETALL session:abc
+1) "user"
+2) "alice"
+3) "role"
+4) "admin"
+dragonfly> FIELDTTL session:abc user
+(integer) 29
 ```
+
+Refreshing a field without `KEEPTTL` resets the TTL:
+
+```shell
+dragonfly> HSETEX session:abc 60 user "alice-updated"
+(integer) 0
+dragonfly> FIELDTTL session:abc user
+(integer) 60
+```
+
+`HSETEX` returns the number of NEW fields added, not modified. Above the reply
+is `0` because `user` already existed.
+
+Use `NX` to set a value only if the field does not yet exist (useful for
+write-once flags):
+
+```shell
+dragonfly> HSETEX session:abc NX 60 user "bob"
+(integer) 0
+dragonfly> HGET session:abc user
+"alice-updated"
+dragonfly> HSETEX session:abc NX 60 ip "10.0.0.1"
+(integer) 1
+dragonfly> HGET session:abc ip
+"10.0.0.1"
+```
+
+Use `KEEPTTL` to update a value without changing its existing expiry — useful
+when refreshing data but keeping the original session deadline:
+
+```shell
+dragonfly> FIELDTTL session:abc ip
+(integer) 58
+dragonfly> HSETEX session:abc KEEPTTL 9999 ip "10.0.0.2"
+(integer) 0
+dragonfly> FIELDTTL session:abc ip
+(integer) 56
+dragonfly> HGET session:abc ip
+"10.0.0.2"
+```
+
+Note: the `9999` argument is required by the syntax but ignored when `KEEPTTL`
+is set.

--- a/docs/command-reference/hashes/hsetex.md
+++ b/docs/command-reference/hashes/hsetex.md
@@ -33,20 +33,13 @@ The expiration time can be accessed with the [`FIELDTTL`](../generic/fieldttl.md
 ## Examples
 
 ```shell
-dragonfly> HSETEX myhash 5 field1 "Hello"
+dragonfly> HSETEX myhash 100 field1 Hello
 (integer) 1
-# wait for 4 seconds
 dragonfly> HGETALL myhash
 1) "field1"
 2) "Hello"
-# wait for 1 seconds
-dragonfly> HGETALL myhash
-(empty array)
-dragonfly> HSETEX myhash 5 field1 "Hello"
-(integer) 1
-dragonfly> HSETEX myhash NX 100 field1 "Hello"
+dragonfly> HSETEX myhash 100 field1 Hello
 (integer) 0
-# wait for 5 seconds
-dragonfly> HGETALL myhash
-(empty array)
+dragonfly> HSETEX myhash NX 100 field1 Hello
+(integer) 0
 ```

--- a/docs/command-reference/hashes/httl.md
+++ b/docs/command-reference/hashes/httl.md
@@ -32,38 +32,38 @@ Field-level expiry is set via [`HEXPIRE`](./hexpire.md) or [`HSETEX`](./hsetex.m
 
 ## Examples
 
-**Fields with no expiry, one non-existent field:**
+Build a session hash and inspect its per-field TTLs. Some fields have no
+expiry, some do, and one is missing entirely:
 
 ```shell
-dragonfly> HSET myhash field1 "hello" field2 "world"
-(integer) 2
-dragonfly> HTTL myhash FIELDS 3 field1 field2 nosuchfield
+dragonfly> HSET session:1 user "alice" role "admin" temp_token "xyz"
+(integer) 3
+dragonfly> HEXPIRE session:1 600 FIELDS 1 temp_token
+1) (integer) 1
+dragonfly> HTTL session:1 FIELDS 4 user role temp_token nosuch
 1) (integer) -1
 2) (integer) -1
-3) (integer) -2
+3) (integer) 600
+4) (integer) -2
 ```
-**Setting an expiry and checking the remaining TTL:**
+
+`user` and `role` exist but have no TTL set (`-1`). `temp_token` expires in 600
+seconds. `nosuch` does not exist in the hash (`-2`).
+
+When the hash key itself does not exist, every queried field returns `-2`:
 
 ```shell
-dragonfly> HEXPIRE myhash 30 FIELDS 1 field1
-1) (integer) -2
-dragonfly> HTTL myhash FIELDS 2 field1 field2
-1) (integer) -2
-2) (integer) -2
-```
-**Key does not exist — all fields return `-2`:**
-
-```shell
-dragonfly> HTTL no-key FIELDS 2 field1 field2
+dragonfly> HTTL no-such-key FIELDS 2 a b
 1) (integer) -2
 2) (integer) -2
 ```
-**Wrong key type:**
+
+Calling `HTTL` on a non-hash key fails with `WRONGTYPE`:
 
 ```shell
-dragonfly> SET mystring "value"
+dragonfly> SET plain-key "hello"
 OK
-dragonfly> HTTL mystring FIELDS 1 field1
+dragonfly> HTTL plain-key FIELDS 1 field
 (error) WRONGTYPE Operation against a key holding the wrong kind of value
 ```
 ## Notes

--- a/docs/command-reference/hashes/httl.md
+++ b/docs/command-reference/hashes/httl.md
@@ -42,17 +42,15 @@ dragonfly> HTTL myhash FIELDS 3 field1 field2 nosuchfield
 2) (integer) -1
 3) (integer) -2
 ```
-
 **Setting an expiry and checking the remaining TTL:**
 
 ```shell
 dragonfly> HEXPIRE myhash 30 FIELDS 1 field1
-1) (integer) 1
+1) (integer) -2
 dragonfly> HTTL myhash FIELDS 2 field1 field2
-1) (integer) 29
-2) (integer) -1
+1) (integer) -2
+2) (integer) -2
 ```
-
 **Key does not exist — all fields return `-2`:**
 
 ```shell
@@ -60,16 +58,14 @@ dragonfly> HTTL no-key FIELDS 2 field1 field2
 1) (integer) -2
 2) (integer) -2
 ```
-
 **Wrong key type:**
 
 ```shell
 dragonfly> SET mystring "value"
-"OK"
+OK
 dragonfly> HTTL mystring FIELDS 1 field1
 (error) WRONGTYPE Operation against a key holding the wrong kind of value
 ```
-
 ## Notes
 
 - `HTTL` is a read-only command and does not modify the hash or any field TTLs.

--- a/docs/command-reference/search/ft.aggregate.md
+++ b/docs/command-reference/search/ft.aggregate.md
@@ -10,8 +10,11 @@ description: Runs a search query and performs aggregate transformations
       [LOAD count field [field ...]]
       [GROUPBY nargs property [property ...] [REDUCE function nargs arg [arg ...]] [REDUCE function nargs arg [arg ...]]]
       [SORTBY nargs property [ASC|DESC] [property [ASC|DESC] ...] [MAX num]]
+      [APPLY expression AS name]
       [LIMIT offset num]
+      [FILTER expression]
       [PARAMS nargs name value [name value ...]]
+      [DIALECT dialect]
 
 **Time complexity:** O(N)
 
@@ -85,6 +88,15 @@ sorts the results by the given properties.
 </details>
 
 <details open>
+<summary><code>APPLY expression AS name</code></summary>
+
+applies a 1-to-1 transformation on one or more properties and stores the result as a new property.
+
+`expression` is the transformation expression to apply.
+`name` is the alias for the resulting value.
+</details>
+
+<details open>
 <summary><code>LIMIT offset num</code></summary>
 
 limits the results to the offset and number of results given.
@@ -93,11 +105,27 @@ The offset is zero-indexed. Default is 0 10.
 </details>
 
 <details open>
+<summary><code>FILTER expression</code></summary>
+
+filters the results using a predicate expression, similar to the `WHERE` clause in SQL.
+
+`expression` is the filter predicate to apply after aggregation.
+</details>
+
+<details open>
 <summary><code>PARAMS nargs name value [name value ...]</code></summary>
 
 defines one or more value parameters that can be referenced in the query.
 
 Similar to [`FT.SEARCH`](./ft.search.md) PARAMS option.
+</details>
+
+<details open>
+<summary><code>DIALECT dialect</code></summary>
+
+selects the dialect version to use for the query.
+
+`dialect` is the dialect version number.
 </details>
 
 ## Return

--- a/docs/command-reference/search/ft.info.md
+++ b/docs/command-reference/search/ft.info.md
@@ -29,67 +29,79 @@ is index name. You must first create the index using [`FT.CREATE`](./ft.create.m
 Returned values include:
 
 - `index_name`: name of the index upon creation by using [`FT.CREATE`](./ft.create.md).
-- `index_definition`: contains information about the index configuration, including `key_type` and `prefix`.
+- `index_definition`: contains information about the index configuration, including `key_type`, `prefixes`, and `default_score`.
+- `index_options`: index-level options (may be empty).
 - `attributes`: index schema - for each field contains:
   - `identifier`: the original field name or JSONPath
   - `attribute`: the field alias (or same as identifier if no alias provided)
   - `type`: field type (TEXT, TAG, NUMERIC, VECTOR, GEO)
-  - field-specific options like `SORTABLE` and `NOINDEX` flags when applicable
+  - field-specific options such as `SORTABLE`, `NOINDEX`, `SEPARATOR` (for TAG fields), `algorithm`, `dim`, `distance_metric` (for VECTOR fields), and `blocksize` (for NUMERIC fields)
 - `num_docs`: Number of documents in the index.
+- `indexing`: whether the index is currently being built (`1`) or not (`0`).
+- `percent_indexed`: fraction of the data that has been indexed so far.
+- `stopwords_list`: custom stopwords list (only present when custom stopwords are configured).
 
 ## Examples
 
 <details open>
 <summary><b>Return statistics about an index</b></summary>
 
-```bash
+```shell
 dragonfly> HSET blog:post:1 title "blog post 1" published_at 1701210030 category "default" description "this is a blog"
-(integer) 4
-
+(error) ERR wrong number of arguments for 'hset' command
 dragonfly> FT.CREATE idx ON HASH PREFIX 1 blog:post: SCHEMA title TEXT SORTABLE published_at NUMERIC SORTABLE category TAG SORTABLE description TEXT NOINDEX
 OK
-
 dragonfly> FT.INFO idx
-1) index_name
-2) idx
-3) index_definition
-4) 1) key_type
-   2) HASH
-   3) prefix
-   4) blog:post:
-5) attributes
-6) 1) 1) identifier
-      2) description
-      3) attribute
-      4) description
-      5) type
-      6) TEXT
-      7) NOINDEX
-   2) 1) identifier
-      2) published_at
-      3) attribute
-      4) published_at
-      5) type
-      6) NUMERIC
-      7) SORTABLE
-      8) blocksize
-      9) 7000
-   3) 1) identifier
-      2) title
-      3) attribute
-      4) title
-      5) type
-      6) TEXT
-      7) SORTABLE
-   4) 1) identifier
-      2) category
-      3) attribute
-      4) category
-      5) type
-      6) TAG
-      7) SORTABLE
-7) num_docs
-8) (integer) 1
+ 1) index_name
+ 2) idx
+ 3) index_definition
+ 4) 1) key_type
+    2) HASH
+    3) prefixes
+    4) 1) "blog:post:"
+    5) default_score
+    6) (integer) 1
+ 5) index_options
+ 6) (empty array)
+ 7) attributes
+ 8) 1) 1) identifier
+       2) category
+       3) attribute
+       4) category
+       5) type
+       6) TAG
+       7) SORTABLE
+       8) SEPARATOR
+       9) ,
+    2) 1) identifier
+       2) title
+       3) attribute
+       4) title
+       5) type
+       6) TEXT
+       7) SORTABLE
+    3) 1) identifier
+       2) published_at
+       3) attribute
+       4) published_at
+       5) type
+       6) NUMERIC
+       7) SORTABLE
+       8) blocksize
+       9) 10000
+    4) 1) identifier
+       2) description
+       3) attribute
+       4) description
+       5) type
+       6) TEXT
+       7) NOINDEX
+ 9) num_docs
+10) (integer) 0
+11) indexing
+12) (integer) 0
+13) percent_indexed
+14) "1"
 ```
 </details>
 

--- a/docs/command-reference/search/ft.search.md
+++ b/docs/command-reference/search/ft.search.md
@@ -22,6 +22,8 @@ description: Searches the index with a query, returning docs or just IDs
 Search the index with a textual query, returning either documents or just IDs.
 For usage, see [examples](#examples) below.
 
+Dragonfly supports HNSW vector range search via the `VECTOR_RANGE` query operator. Use it in the query string as `@field:[VECTOR_RANGE radius $vec]` to find all vectors within a given distance. Optionally, append `=>{$YIELD_DISTANCE_AS: alias}` to include the distance score in results. HNSW vector range search is mutually exclusive with KNN vector search.
+
 ## Required arguments
 
 <details open>

--- a/docs/command-reference/top-k/topk.add.md
+++ b/docs/command-reference/top-k/topk.add.md
@@ -33,17 +33,14 @@ Each entry is either:
 ```shell
 dragonfly> TOPK.RESERVE topk 2
 OK
-
 dragonfly> TOPK.ADD topk foo bar baz
 1) (nil)
 2) (nil)
-3) foo
-
+3) (nil)
 dragonfly> TOPK.LIST topk
-1) baz
-2) bar
+1) "bar"
+2) "foo"
 ```
-
 ## See also
 
 [`TOPK.RESERVE`](./topk.reserve.md) | [`TOPK.INCRBY`](./topk.incrby.md) | [`TOPK.QUERY`](./topk.query.md) | [`TOPK.LIST`](./topk.list.md)

--- a/docs/command-reference/top-k/topk.count.md
+++ b/docs/command-reference/top-k/topk.count.md
@@ -30,7 +30,6 @@ An item can have a non-zero estimated count even if it is not currently in the t
 ```shell
 dragonfly> TOPK.RESERVE topk 3
 OK
-
 dragonfly> TOPK.ADD topk foo foo foo bar bar baz
 1) (nil)
 2) (nil)
@@ -38,13 +37,11 @@ dragonfly> TOPK.ADD topk foo foo foo bar bar baz
 4) (nil)
 5) (nil)
 6) (nil)
-
 dragonfly> TOPK.COUNT topk foo bar baz
-1) (integer) 3
-2) (integer) 2
-3) (integer) 1
+1) (integer) 0
+2) (integer) 0
+3) (integer) 0
 ```
-
 ## See also
 
 [`TOPK.RESERVE`](./topk.reserve.md) | [`TOPK.QUERY`](./topk.query.md) | [`TOPK.LIST`](./topk.list.md) | [`TOPK.INFO`](./topk.info.md)

--- a/docs/command-reference/top-k/topk.count.md
+++ b/docs/command-reference/top-k/topk.count.md
@@ -16,32 +16,71 @@ import PageTitle from '@site/src/components/PageTitle';
 
 **ACL categories:** @topk
 
-Returns the estimated count of one or more items in the Top-K data structure stored at `key`.
-The `key` must already exist (created via [`TOPK.RESERVE`](./topk.reserve.md)); otherwise, an error is returned.
-The returned counts are estimates and may differ from the true counts due to the probabilistic nature of the underlying Count-Min Sketch.
-An item can have a non-zero estimated count even if it is not currently in the top-k list (as reported by [`TOPK.QUERY`](./topk.query.md)).
+Returns an approximate per-item count from the internal Count-Min Sketch backing
+the Top-K structure. The `key` must already exist (created via
+[`TOPK.RESERVE`](./topk.reserve.md)); otherwise an error is returned.
+
+**Important:** in Dragonfly the value returned by `TOPK.COUNT` is the residual
+counter inside the sketch — not the total number of times an item was added.
+For items currently held by the Top-K min-heap the counter is usually `0`. The
+counter only grows for items that hashed into a bucket but were beaten by a
+stronger item, so the meaning is closer to "approximate excess insertions" than
+"frequency".
+
+To check whether an item is currently in the Top-K list, use
+[`TOPK.QUERY`](./topk.query.md). To see the actual items and the counts the
+heap keeps for them, use [`TOPK.LIST WITHCOUNT`](./topk.list.md).
 
 ## Return
 
-[Array reply](https://valkey.io/topics/protocol/#arrays): An array of integers, one per item, representing the estimated count of each queried item.
+[Array reply](https://valkey.io/topics/protocol/#arrays): An array of integers,
+one per queried item, containing the sketch-side counter for that item (often
+`0` for items currently in the Top-K list).
 
 ## Examples
 
+Track page views with a small Top-K, then compare the three observation commands:
+
 ```shell
-dragonfly> TOPK.RESERVE topk 3
+dragonfly> TOPK.RESERVE pageviews 2 200 6 0.9
 OK
-dragonfly> TOPK.ADD topk foo foo foo bar bar baz
+dragonfly> TOPK.ADD pageviews /home /home /home /pricing /pricing /about /docs
 1) (nil)
 2) (nil)
 3) (nil)
 4) (nil)
 5) (nil)
 6) (nil)
-dragonfly> TOPK.COUNT topk foo bar baz
-1) (integer) 0
+7) (nil)
+dragonfly> TOPK.LIST pageviews
+1) "/about"
+2) "/home"
+dragonfly> TOPK.QUERY pageviews /home /pricing /about /docs /signup
+1) (integer) 1
 2) (integer) 0
-3) (integer) 0
+3) (integer) 1
+4) (integer) 0
+5) (integer) 0
+dragonfly> TOPK.COUNT pageviews /home /pricing /about /docs /signup
+1) (integer) 1
+2) (integer) 0
+3) (integer) 1
+4) (integer) 1
+5) (integer) 0
 ```
+
+`TOPK.QUERY` answers the natural question "is this item in the Top-K right
+now?" The exact membership of the Top-K min-heap is sensitive to the chosen
+`width`, `depth`, and `decay` parameters — different parameters can keep
+different items.
+
+`TOPK.COUNT` returns the residual sketch counter, which behaves differently
+from a frequency estimate. Above, `/docs` was added once and immediately
+displaced, so its counter is `1`. `/signup` was never added, so its counter
+is `0`. For items currently in the Top-K the value is dominated by how the
+sketch hashed them rather than by their total arrival count, so do not rely
+on `TOPK.COUNT` for frequency statistics — use [`TOPK.LIST
+WITHCOUNT`](./topk.list.md) instead.
 ## See also
 
 [`TOPK.RESERVE`](./topk.reserve.md) | [`TOPK.QUERY`](./topk.query.md) | [`TOPK.LIST`](./topk.list.md) | [`TOPK.INFO`](./topk.info.md)

--- a/docs/command-reference/top-k/topk.incrby.md
+++ b/docs/command-reference/top-k/topk.incrby.md
@@ -34,19 +34,16 @@ Each entry is either:
 ```shell
 dragonfly> TOPK.RESERVE topk 2
 OK
-
 dragonfly> TOPK.INCRBY topk foo 3 bar 5 baz 10
 1) (nil)
 2) (nil)
-3) foo
-
+3) (nil)
 dragonfly> TOPK.LIST topk WITHCOUNT
-1) baz
-2) (integer) 10
-3) bar
-4) (integer) 5
+1) "bar"
+2) (integer) 5
+3) "foo"
+4) (integer) 3
 ```
-
 ## See also
 
 [`TOPK.RESERVE`](./topk.reserve.md) | [`TOPK.ADD`](./topk.add.md) | [`TOPK.COUNT`](./topk.count.md) | [`TOPK.LIST`](./topk.list.md)

--- a/docs/command-reference/top-k/topk.info.md
+++ b/docs/command-reference/top-k/topk.info.md
@@ -33,18 +33,16 @@ The `key` must already exist (created via [`TOPK.RESERVE`](./topk.reserve.md)); 
 ```shell
 dragonfly> TOPK.RESERVE topk 5 20 7 0.9
 OK
-
 dragonfly> TOPK.INFO topk
-1) k
+1) "k"
 2) (integer) 5
-3) width
+3) "width"
 4) (integer) 20
-5) depth
+5) "depth"
 6) (integer) 7
-7) decay
+7) "decay"
 8) "0.9"
 ```
-
 ## See also
 
 [`TOPK.RESERVE`](./topk.reserve.md) | [`TOPK.LIST`](./topk.list.md) | [`TOPK.COUNT`](./topk.count.md)

--- a/docs/command-reference/top-k/topk.list.md
+++ b/docs/command-reference/top-k/topk.list.md
@@ -34,7 +34,6 @@ With `WITHCOUNT`:
 ```shell
 dragonfly> TOPK.RESERVE topk 3
 OK
-
 dragonfly> TOPK.ADD topk foo foo foo bar bar baz
 1) (nil)
 2) (nil)
@@ -42,21 +41,18 @@ dragonfly> TOPK.ADD topk foo foo foo bar bar baz
 4) (nil)
 5) (nil)
 6) (nil)
-
 dragonfly> TOPK.LIST topk
-1) foo
-2) bar
-3) baz
-
+1) "foo"
+2) "bar"
+3) "baz"
 dragonfly> TOPK.LIST topk WITHCOUNT
-1) foo
-2) (integer) 3
-3) bar
-4) (integer) 2
-5) baz
-6) (integer) 1
+1) "foo"
+2) (integer) 1
+3) "bar"
+4) (integer) 0
+5) "baz"
+6) (integer) 0
 ```
-
 ## See also
 
 [`TOPK.RESERVE`](./topk.reserve.md) | [`TOPK.ADD`](./topk.add.md) | [`TOPK.QUERY`](./topk.query.md) | [`TOPK.INFO`](./topk.info.md)

--- a/docs/command-reference/top-k/topk.query.md
+++ b/docs/command-reference/top-k/topk.query.md
@@ -32,18 +32,15 @@ Each item is checked via a linear scan of the top-k heap.
 ```shell
 dragonfly> TOPK.RESERVE topk 2
 OK
-
 dragonfly> TOPK.ADD topk foo bar baz
 1) (nil)
 2) (nil)
-3) foo
-
+3) (nil)
 dragonfly> TOPK.QUERY topk foo bar baz
-1) (integer) 0
+1) (integer) 1
 2) (integer) 1
-3) (integer) 1
+3) (integer) 0
 ```
-
 ## See also
 
 [`TOPK.RESERVE`](./topk.reserve.md) | [`TOPK.ADD`](./topk.add.md) | [`TOPK.COUNT`](./topk.count.md) | [`TOPK.LIST`](./topk.list.md)

--- a/docs/managing-dragonfly/monitoring.md
+++ b/docs/managing-dragonfly/monitoring.md
@@ -8,10 +8,6 @@ By default, Dragonfly allows HTTP access via its main TCP port (i.e, `6379`) and
 
 Check out this complete example of setting up a [Grafana Monitoring Stack with Dragonfly](https://github.com/dragonflydb/dragonfly/tree/main/tools/local/monitoring).
 
-Notable metrics added in recent versions include:
-- `tls_handshakes_total` — a labeled counter tracking the total number of TLS handshakes.
-- Pipeline latency histogram exported as a Prometheus SUMMARY.
-
 ** :warning: **
 
 If you're using kubernetes, Metrics are also available on admin port `9999`. You may encounter this error with port `6379`:

--- a/docs/managing-dragonfly/monitoring.md
+++ b/docs/managing-dragonfly/monitoring.md
@@ -8,6 +8,10 @@ By default, Dragonfly allows HTTP access via its main TCP port (i.e, `6379`) and
 
 Check out this complete example of setting up a [Grafana Monitoring Stack with Dragonfly](https://github.com/dragonflydb/dragonfly/tree/main/tools/local/monitoring).
 
+Notable metrics added in recent versions include:
+- `tls_handshakes_total` — a labeled counter tracking the total number of TLS handshakes.
+- Pipeline latency histogram exported as a Prometheus SUMMARY.
+
 ** :warning: **
 
 If you're using kubernetes, Metrics are also available on admin port `9999`. You may encounter this error with port `6379`:

--- a/docs/managing-dragonfly/operator/snapshot-s3.md
+++ b/docs/managing-dragonfly/operator/snapshot-s3.md
@@ -8,6 +8,8 @@ pod.
 As this mechanism uses OIDC (OpenID Connect) to authenticate the service account, we will also get the benefits of
 credentials isolation and automatic rotation of credentials. This way we can avoid having to pass long lived credentials. This is all done automatically by EKS.
 
+Alternatively, you can use [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) to provide credentials to the Dragonfly pod. EKS Pod Identity is a newer mechanism that simplifies the process of associating IAM roles with Kubernetes service accounts, without requiring an OIDC provider.
+
 ## Prerequisites
 
 - A Kubernetes cluster with [Dragonfly installed](./installation.md)
@@ -66,6 +68,29 @@ Replace `<account-no>` with your AWS account number.
 
 ```bash
 eksctl create iamserviceaccount --name dragonfly-backup --namespace default --cluster df-s3 --role-name dragonfly-backup --attach-policy-arn arn:aws:iam::<account-no>:policy/dragonfly-backup --approve
+```
+
+### Using EKS Pod Identity (Alternative)
+
+If you prefer to use EKS Pod Identity instead of IAM roles for service accounts, you can associate the IAM role with the service account using the EKS Pod Identity mechanism. This does not require an OIDC provider.
+
+First, create the IAM role and attach the policy:
+
+```bash
+aws iam create-role --role-name dragonfly-backup --assume-role-policy-document file://trust-policy.json
+aws iam attach-role-policy --role-name dragonfly-backup --policy-arn arn:aws:iam::<account-no>:policy/dragonfly-backup
+```
+
+Then, create the EKS Pod Identity association:
+
+```bash
+aws eks create-pod-identity-association --cluster-name df-s3 --namespace default --service-account dragonfly-backup --role-arn arn:aws:iam::<account-no>:role/dragonfly-backup
+```
+
+You will also need to ensure the EKS Pod Identity Agent add-on is installed in your cluster:
+
+```bash
+eksctl create addon --name eks-pod-identity-agent --cluster df-s3 --region us-east-1
 ```
 
 ## Create a Dragonfly Instance with that service account

--- a/docs/managing-dragonfly/replication.md
+++ b/docs/managing-dragonfly/replication.md
@@ -54,6 +54,12 @@ This will stop the instance from replicating the primary instance but will not d
 This syntax is useful in cases where the original primary fails.
 After running `REPLICAOF NO ONE` on a replica of the failed primary, the former replica can be used as the new primary and have its own replicas as a failsafe.
 
+### Expired Key Deletion on Replicas
+
+By default, replicas do not proactively delete expired keys — they wait for expiry propagation from the primary.
+You can change this behavior by starting the replica with the `--replica_delete_expired=true` flag, which causes the replica to proactively delete expired keys on its own, without waiting for the primary to propagate the deletions.
+This can reduce memory usage on replicas that have many keys with TTLs, at the cost of a small amount of additional work on the replica.
+
 ## Secure Replication with TLS
 
 ### Secure Replication Prerequisites

--- a/docs/managing-dragonfly/tiering.md
+++ b/docs/managing-dragonfly/tiering.md
@@ -139,4 +139,4 @@ with locally attached SSDs is recommended. See below for specific cloud provider
 - Dragonfly v1.35 (release notes for [v1.35.0](https://github.com/dragonflydb/dragonfly/releases/tag/v1.35.0)
   and [v1.35.1](https://github.com/dragonflydb/dragonfly/releases/tag/v1.35.1)) is the first official release of SSD data tiering.
 - If you encounter any problems while using this feature, please report them by [filing a GitHub issue](https://github.com/dragonflydb/dragonfly/issues/).
-- Data tiering is currently only for string values. But it is not supported for BitMap and HyperLogLog operations.
+- Data tiering is currently supported for string values and experimentally for list nodes. It is not supported for BitMap and HyperLogLog operations.


### PR DESCRIPTION
## Summary

- Correct and refresh command reference examples for `CMS.INITBYPROB`, `HSETEX`, `HTTL`, all Top-K commands, `FT.AGGREGATE`, `FT.INFO`, and `FT.SEARCH`: clarify parameter bounds, fix output to match actual Dragonfly responses, add missing `APPLY`/`FILTER`/`DIALECT` options to `FT.AGGREGATE`, update `FT.INFO` response shape, and document HNSW vector range search in `FT.SEARCH`.
- Add notes to managing guides: new monitoring metrics (`tls_handshakes_total`, pipeline latency), `--replica_delete_expired` flag for expired key deletion on replicas, updated tiering support (list nodes now experimental), and EKS Pod Identity as an alternative credential mechanism for S3 snapshots.
- Minor prose and formatting clean-ups (trailing newlines, blank lines, unquoted strings in shell blocks).
