### PR TITLE
docs: update flags with additions, removals, and default changes

### DIFF
--- a/docs/managing-dragonfly/flags.md
+++ b/docs/managing-dragonfly/flags.md
@@ -286,11 +286,6 @@ flags which include specified substring in either in the name, description or pa
 
   `default: 0.1`
 
-### `--tiered_storage_write_depth`
-  Maximum number of concurrent stash requests issued by background offload. 
-
-  `default: 200`
-
 ### `--tiered_min_value_size`
   Minimum size of values eligible for offloading. Must be at least 64
 
@@ -511,15 +506,20 @@ flags which include specified substring in either in the name, description or pa
 
   `default: false`
 
-### `--logtostdout`
-  Log messages go to stdout instead of logfiles.
+### `--logbuflevel`
+  Buffer log messages logged at this level or below. (-1 means don't buffer; 0 means buffer INFO only).
 
-  `default: false`
+  `default: 0`
+
+### `--logbufsecs`
+  Buffer log messages for at most this many seconds.
+
+  `default: 30`
 
 ### `--max_log_size`
   Approx. maximum log file size (in MB). A value of 0 will be silently overridden to 1. 
 
-  `default: 1800`
+  `default: 200`
 
 ### `--minloglevel`
   Messages logged at a lower level than this don't actually get logged anywhere. 
@@ -581,6 +581,16 @@ flags which include specified substring in either in the name, description or pa
 
   `default: false`
 
+### `--cluster_coordinator_connect_timeout_ms`
+  Timeout in milliseconds for coordinator to connect to remote shards.
+
+  `default: 3000`
+
+### `--cluster_coordinator_response_timeout_ms`
+  Timeout in milliseconds for coordinator to read responses from remote shards.
+
+  `default: 3000`
+
 ### `--cluster_flush_decommit_memory`
   Decommit memory after flushing slots.
 
@@ -596,6 +606,11 @@ flags which include specified substring in either in the name, description or pa
 
   `default: false`
 
+### `--container_iteration_yield_interval_usec`
+  Yield the fiber every N microseconds during container iteration. 0 disables yielding.
+
+  `default: 0`
+
 ### `--deserialize_hnsw_index`
   Deserialize HNSW vector index graph structure.
 
@@ -610,6 +625,16 @@ flags which include specified substring in either in the name, description or pa
   Enable eviction during heartbeat when rss memory is under pressure. Eviction based on used_memory will still be enabled.
 
   `default: true`
+
+### `--enable_memcache_io_loop_v2`
+  Enable the event-driven IoLoopV2 for non-TLS Memcache connections.
+
+  `default: true`
+
+### `--enable_resp_io_loop_v2`
+  Enable the event-driven IoLoopV2 for non-TLS RESP connections.
+
+  `default: false`
 
 ### `--enable_tcp_defer_accept`
   Enable TCP_DEFER_ACCEPT option on server sockets.
@@ -630,11 +655,6 @@ flags which include specified substring in either in the name, description or pa
   If true, uses flat json implementation.
 
   `default: false`
-
-### `--experimental_io_loop_v2`
-  Use the new io loop implementation.
-
-  `default: true`
 
 ### `--experimental_replicaof_v2`
   Use ReplicaOfV2 algorithm for initiating replication.
@@ -676,6 +696,11 @@ flags which include specified substring in either in the name, description or pa
 
   `default: true`
 
+### `--journal_omit_redundant_writes`
+  If true, omit journal writes for keys during full sync that are yet to be reached by the serialization loop. Reduces full sync overhead.
+
+  `default: true`
+
 ### `--jsonpathv2`
   If true, uses Dragonfly jsonpath implementation, otherwise uses legacy jsoncons implementation.
 
@@ -700,6 +725,16 @@ flags which include specified substring in either in the name, description or pa
   Tiering threshold for lists. Default - no tiering.
 
   `default: 0`
+
+### `--listpack_max_bytes`
+  Maximum total bytes of a hash in listpack encoding before converting to a hash table.
+
+  `default: 1024`
+
+### `--listpack_max_field_len`
+  Maximum length of a hash field or value to be stored in listpack encoding.
+
+  `default: 64`
 
 ### `--locktag_delimiter`
   If set, this char is used to extract a lock tag by looking at delimiters, like hash tags. If unset, regular hashtag extraction is done (with `{}`). Must be used with `--lock_on_hashtags`.
@@ -869,7 +904,7 @@ flags which include specified substring in either in the name, description or pa
 ### `--rdb_sbf_chunked`
   Enable new save format for saving SBFs in chunks.
 
-  `default: false`
+  `default: true`
 
 ### `--registered_buffer_size`
   Size of registered buffer for IoUring fixed read/writes.
@@ -916,6 +951,11 @@ flags which include specified substring in either in the name, description or pa
 
   `default: 1.25`
 
+### `--s3_use_helio_client`
+  If true, use helio's native S3 client; if false, use aws-sdk-cpp. Only meaningful when compiled with AWS support; otherwise the helio client is always used.
+
+  `default: true`
+
 ### `--save_schedule`
   Deprecated. Please use `--snapshot_cron` instead.
 
@@ -953,6 +993,11 @@ flags which include specified substring in either in the name, description or pa
 
 ### `--serialize_hnsw_index`
   Serialize HNSW vector index graph structure.
+
+  `default: false`
+
+### `--serialization_tagged_chunks`
+  Allow serializer output to be split into tagged chunks and reassembled by receiver.
 
   `default: false`
 
@@ -1021,6 +1066,11 @@ flags which include specified substring in either in the name, description or pa
 
   `default: 0B`
 
+### `--tiered_max_pending_stash_bytes`
+  Maximum bytes in-flight to disk before rejecting new stashes or applying client backpressure. Allows batching writes to saturate disk I/O even with few clients.
+
+  `default: 256.0KiB`
+
 ### `--tls_cipher_suites`
   TLS ciphers configuration for TLS 1.3.
 
@@ -1080,6 +1130,11 @@ flags which include specified substring in either in the name, description or pa
   Use range tree for numeric index. If false, use a simple implementation with btree_set. Range tree is more memory efficient and faster for range queries, but slower for single value queries.
 
   `default: true`
+
+### `--use_oah_set`
+  If true, store SET values in OAHSet instead of StringSet.
+
+  `default: false`
 
 ### `--user`
   If not empty - drop privileges to this user (and their primary group) after binding ports. Accepts username or numeric uid. If `--dir` is set, chowns the data directory to this user.


### PR DESCRIPTION
- Add new flags: `--logbuflevel`, `--logbufsecs`, `--cluster_coordinator_connect_timeout_ms`, `--cluster_coordinator_response_timeout_ms`, `--container_iteration_yield_interval_usec`, `--enable_memcache_io_loop_v2`, `--enable_resp_io_loop_v2`, `--journal_omit_redundant_writes`, `--listpack_max_bytes`, `--listpack_max_field_len`, `--s3_use_helio_client`, `--serialization_tagged_chunks`, `--tiered_max_pending_stash_bytes`, `--use_oah_set`
- Remove deprecated/replaced flags: `--tiered_storage_write_depth`, `--logtostdout`, `--experimental_io_loop_v2`
- Update default values for `--max_log_size` (1800→200), `--rdb_sbf_chunked` (false→true)