### PR TITLE
docs: sync command-reference + managing-dragonfly to Dragonfly v1.39.0

### DIFF
--- a/docs/command-reference/compatibility.md
+++ b/docs/command-reference/compatibility.md
@@ -350,6 +350,7 @@ sidebar_position: 0
 |                                              | <span class="command">JSON.TYPE</span>                     | <span class="support supported">Fully supported</span>   |
 | <span class="family">Search</span>           | <span class="command">FT.CREATE</span>                     | <span class="support partial">Partially supported</span> |
 |                                              | <span class="command">FT.SEARCH</span>                     | <span class="support partial">Partially supported</span> |
+|                                              | <span class="command">FT.HYBRID</span>                     | <span class="support supported">Fully supported</span>   |
 |                                              | <span class="command">FT.ALTER</span>                      | <span class="support supported">Fully supported</span>   |
 |                                              | <span class="command">FT.DROPINDEX</span>                  | <span class="support partial">Partially supported</span> |
 |                                              | <span class="command">FT.INFO</span>                       | <span class="support partial">Partially supported</span> |

--- a/docs/command-reference/generic/restore.md
+++ b/docs/command-reference/generic/restore.md
@@ -31,6 +31,7 @@ If the `ABSTTL` modifier was used, `ttl` should represent an absolute
 exists unless you use the `REPLACE` modifier.
 
 `!RESTORE` checks the data checksum. If it does not match an error is returned.
+Additionally, listpack and intset payloads are deeply validated on restore.
 
 ## Return
 
@@ -38,15 +39,21 @@ exists unless you use the `REPLACE` modifier.
 
 ## Examples
 
+Serialize a key with `DUMP`, then recreate it from that payload with `RESTORE`:
+
 ```
-dragonfly> DEL mykey
-0
-dragonfly> RESTORE mykey 0 "\x0e\x01\x11\x11\x00\x00\x00\x0e\x00\x00\x00\x03\x00\x00\xf2\x02\xf3\x02\xf4\xff\t\x00\xfa\x81\x98P\x85\xf8\xd9\xed"
+dragonfly> SET greeting Hello
 OK
-dragonfly> TYPE mykey
-list
-dragonfly> LRANGE mykey 0 -1
-1) "1"
-2) "2"
-3) "3"
+dragonfly> DUMP greeting
+"\x00\x05Hello\t\x00l;\xa6$i\x83\x9c2"
+dragonfly> DEL greeting
+(integer) 1
+dragonfly> RESTORE greeting 0 "\x00\x05Hello\t\x00l;\xa6$i\x83\x9c2"
+OK
+dragonfly> GET greeting
+"Hello"
 ```
+
+The serialized value is a binary blob produced by `DUMP` and is tied to the
+server's RDB version — a payload dumped from a different version may be rejected
+by the version/checksum check described above.

--- a/docs/command-reference/hashes/hsetex.md
+++ b/docs/command-reference/hashes/hsetex.md
@@ -35,7 +35,7 @@ The expiration time can be accessed with the [`FIELDTTL`](../generic/fieldttl.md
 Cache a user session with a 30-second TTL on every field:
 
 ```shell
-dragonfly> HSETEX session:abc 30 user "alice" role "admin"
+dragonfly> HSETEX session:abc 30 user alice role admin
 (integer) 2
 dragonfly> HGETALL session:abc
 1) "user"
@@ -43,30 +43,36 @@ dragonfly> HGETALL session:abc
 3) "role"
 4) "admin"
 dragonfly> FIELDTTL session:abc user
-(integer) 29
+(integer) 30
 ```
 
-Refreshing a field without `KEEPTTL` resets the TTL:
+Refreshing a field re-sets its TTL. `HSETEX` returns the number of NEW fields
+added, not modified, so the second call below replies `0` because `user`
+already existed:
 
 ```shell
-dragonfly> HSETEX session:abc 60 user "alice-updated"
+dragonfly> HSETEX session:abc 30 user alice
+(integer) 1
+dragonfly> HSETEX session:abc 60 user alice-updated
 (integer) 0
 dragonfly> FIELDTTL session:abc user
 (integer) 60
-```
-
-`HSETEX` returns the number of NEW fields added, not modified. Above the reply
-is `0` because `user` already existed.
-
-Use `NX` to set a value only if the field does not yet exist (useful for
-write-once flags):
-
-```shell
-dragonfly> HSETEX session:abc NX 60 user "bob"
-(integer) 0
 dragonfly> HGET session:abc user
 "alice-updated"
-dragonfly> HSETEX session:abc NX 60 ip "10.0.0.1"
+```
+
+Use `NX` to set a value only if the field does not yet exist (useful for
+write-once flags). `NX` leaves an existing field untouched and replies `0`,
+while a brand-new field is added and replies `1`:
+
+```shell
+dragonfly> HSETEX session:abc 60 user alice
+(integer) 1
+dragonfly> HSETEX session:abc NX 60 user bob
+(integer) 0
+dragonfly> HGET session:abc user
+"alice"
+dragonfly> HSETEX session:abc NX 60 ip 10.0.0.1
 (integer) 1
 dragonfly> HGET session:abc ip
 "10.0.0.1"
@@ -76,15 +82,17 @@ Use `KEEPTTL` to update a value without changing its existing expiry — useful
 when refreshing data but keeping the original session deadline:
 
 ```shell
+dragonfly> HSETEX session:abc 60 ip 10.0.0.1
+(integer) 1
 dragonfly> FIELDTTL session:abc ip
-(integer) 58
-dragonfly> HSETEX session:abc KEEPTTL 9999 ip "10.0.0.2"
+(integer) 60
+dragonfly> HSETEX session:abc KEEPTTL 9999 ip 10.0.0.2
 (integer) 0
 dragonfly> FIELDTTL session:abc ip
-(integer) 56
+(integer) 60
 dragonfly> HGET session:abc ip
 "10.0.0.2"
 ```
 
 Note: the `9999` argument is required by the syntax but ignored when `KEEPTTL`
-is set.
+is set — the TTL above stays at `60`.

--- a/docs/command-reference/search/ft.aggregate.md
+++ b/docs/command-reference/search/ft.aggregate.md
@@ -13,6 +13,9 @@ description: Runs a search query and performs aggregate transformations
       [APPLY expression AS name]
       [LIMIT offset num]
       [FILTER expression]
+      [WITHSCORES]
+      [ADDSCORES]
+      [SCORER scorer]
       [PARAMS nargs name value [name value ...]]
       [DIALECT dialect]
 
@@ -112,6 +115,24 @@ The offset is zero-indexed. Default is 0 10.
 filters the results using a predicate expression, similar to the `WHERE` clause in SQL.
 
 `expression` is the filter predicate to apply after aggregation.
+</details>
+
+<details open>
+<summary><code>WITHSCORES</code></summary>
+
+is accepted for compatibility with [`FT.SEARCH`](./ft.search.md) but has no effect on `FT.AGGREGATE` — it is silently ignored. To include the score in aggregate output, use `ADDSCORES` instead.
+</details>
+
+<details open>
+<summary><code>ADDSCORES</code></summary>
+
+adds the document score to each result as the `__score` field. When no `SCORER` is specified, the default BM25STD scorer is used.
+</details>
+
+<details open>
+<summary><code>SCORER scorer</code></summary>
+
+specifies the scoring function used to compute the score. Supported scorers are `BM25STD`, `TFIDF`, and `TFIDF.DOCNORM`. On its own `SCORER` only sets the scoring function — it does not add a visible score to the output; combine it with `ADDSCORES` to expose the computed score as `__score`.
 </details>
 
 <details open>

--- a/docs/command-reference/search/ft.aggregate.md
+++ b/docs/command-reference/search/ft.aggregate.md
@@ -179,7 +179,7 @@ dragonfly> FT.AGGREGATE products "*" GROUPBY 1 @category REDUCE AVG 1 @price AS 
 
 ## See also
 
-[`FT.SEARCH`](./ft.search.md) | [`FT.CREATE`](./ft.create.md)
+[`FT.SEARCH`](./ft.search.md) | [`FT.CREATE`](./ft.create.md) | [`FT.HYBRID`](./ft.hybrid.md)
 
 ## Related topics
 

--- a/docs/command-reference/search/ft.create.md
+++ b/docs/command-reference/search/ft.create.md
@@ -38,7 +38,7 @@ after the SCHEMA keyword, declares which fields to index:
 
  - `{identifier}` is the name of the field to index:
    - For Hash values, identifier is a field name within the Hash.
-   - For JSON values, the identifier is a JSONPath expression.
+   - For JSON values, the identifier is a JSONPath expression (e.g., `$.title`) or a bare field name (e.g., `title`).
 
  - `AS {attribute}` defines the attribute associated to the identifier.
    For example, you can use this feature to alias a complex JSONPath expression with more memorable (and easier to type) name.
@@ -173,6 +173,12 @@ Index a JSON document using a JSONPath expression.
 
 ``` bash
 dragonfly> FT.CREATE idx ON JSON SCHEMA $.title AS title TEXT $.categories AS categories TAG
+```
+
+Index a JSON document using bare field names (without JSONPath prefix).
+
+``` bash
+dragonfly> FT.CREATE idx2 ON JSON SCHEMA title TEXT categories TAG
 ```
 </details>
 

--- a/docs/command-reference/search/ft.hybrid.md
+++ b/docs/command-reference/search/ft.hybrid.md
@@ -1,0 +1,245 @@
+---
+description: Runs a hybrid search that combines a full-text query with vector similarity and merges the two rankings
+---
+
+# FT.HYBRID
+
+## Syntax
+
+    FT.HYBRID index
+      SEARCH query [SCORER scorer] [YIELD_SCORE_AS name]
+      VSIM @vector_field $param
+        [KNN k [EF_RUNTIME ef] [SHARD_K_RATIO ratio]]
+        [RANGE radius [EPSILON epsilon]]
+        [FILTER filter]
+        [YIELD_SCORE_AS name]
+      [COMBINE RRF [nargs] [CONSTANT constant] [WINDOW window] [YIELD_SCORE_AS name]]
+      [COMBINE LINEAR [nargs] [ALPHA alpha] [BETA beta] [YIELD_SCORE_AS name]]
+      [SCORER scorer]
+      [LOAD count field [AS alias] ...]
+      [LIMIT offset num]
+      [PARAMS nargs name value [name value ...]]
+
+**Time complexity:** O(N) to run the text query (N = documents matching the query) plus O(K) for the vector search (K = candidates examined), and O(M·log(M)) to merge and rank the combined set of M unique candidates.
+
+**ACL categories:** @ft_search
+
+## Description
+
+`FT.HYBRID` runs a **full-text query and a vector-similarity query together** and merges their two ranked result lists into a single ranking. It is useful when lexical relevance (keyword matching) and semantic similarity (vector distance) should both influence the final order — for example, retrieval-augmented generation and semantic product search.
+
+The command has two mandatory parts:
+
+- a `SEARCH` clause that runs a normal full-text query (the same query syntax as [`FT.SEARCH`](./ft.search.md)); and
+- a `VSIM` clause that runs a vector search (`KNN` nearest-neighbor or `RANGE`) against a vector field.
+
+The two result sets are then merged with a `COMBINE` strategy: **Reciprocal Rank Fusion (`RRF`, the default)** or a weighted **`LINEAR`** combination of the normalized scores.
+
+`FT.HYBRID` is a Dragonfly-specific extension.
+
+## Required arguments
+
+<details open>
+<summary><code>index</code></summary>
+
+is the index name. You must first create the index with [`FT.CREATE`](./ft.create.md), and it must contain both the TEXT field(s) used by the query and the VECTOR field used by `VSIM`.
+</details>
+
+<details open>
+<summary><code>SEARCH query</code></summary>
+
+is the full-text query, using the same [query syntax](https://redis.io/docs/latest/develop/interact/search-and-query/query/) as `FT.SEARCH`. If the query is more than a single word, put it in quotes.
+</details>
+
+<details open>
+<summary><code>VSIM @vector_field $param</code></summary>
+
+is the vector-search clause. `@vector_field` is the VECTOR field to search (it must start with `@`), and `$param` is the name of the query-vector parameter (it must start with `$`); the actual vector blob is supplied through `PARAMS`.
+</details>
+
+## Optional arguments
+
+<details open>
+<summary><code>SCORER scorer</code></summary>
+
+selects the scoring function for the text query. Supported scorers are `BM25STD`, `TFIDF`, and `TFIDF.DOCNORM`. May be given inside the `SEARCH` clause or as a trailing option.
+</details>
+
+<details open>
+<summary><code>KNN k [EF_RUNTIME ef] [SHARD_K_RATIO ratio]</code></summary>
+
+returns the `k` nearest neighbors of the query vector. `EF_RUNTIME` sets the HNSW search breadth (larger is more accurate but slower); `SHARD_K_RATIO` multiplies the number of candidates fetched per shard. `KNN` and `RANGE` are mutually exclusive.
+</details>
+
+<details open>
+<summary><code>RANGE radius [EPSILON epsilon]</code></summary>
+
+returns every vector within `radius` distance of the query vector instead of a fixed `k`. `EPSILON` is accepted but currently ignored. `RANGE` cannot be combined with `FILTER`.
+</details>
+
+<details open>
+<summary><code>FILTER filter</code></summary>
+
+applies a pre-filter expression to the vector search. Cannot be combined with `RANGE`.
+</details>
+
+<details open>
+<summary><code>YIELD_SCORE_AS name</code></summary>
+
+exposes a score in the reply under the field `name`. It can be set independently for the text part (inside `SEARCH`), the vector part (inside `VSIM`), and the combined score (inside `COMBINE`).
+</details>
+
+<details open>
+<summary><code>COMBINE RRF [nargs] [CONSTANT constant] [WINDOW window] [YIELD_SCORE_AS name]</code></summary>
+
+merges the two rankings with Reciprocal Rank Fusion — this is the **default** when no `COMBINE` clause is given. `CONSTANT` is the RRF constant (default `60`) and `WINDOW` limits how many ranks per list are fused (default `0`, meaning no limit). `nargs` is the number of arguments in the block.
+</details>
+
+<details open>
+<summary><code>COMBINE LINEAR [nargs] [ALPHA alpha] [BETA beta] [YIELD_SCORE_AS name]</code></summary>
+
+merges the two rankings as a weighted sum of the min-max-normalized scores: `ALPHA` weights the text score and `BETA` weights the vector similarity (both default `0.5`). `nargs` is the number of arguments in the block.
+</details>
+
+<details open>
+<summary><code>LOAD count field [AS alias] ...</code></summary>
+
+returns the listed document fields for each result (optionally aliased with `AS`). Use `LOAD *` to return all fields. Without `LOAD`, each result contains only its key (`__key`) and the combined score.
+</details>
+
+<details open>
+<summary><code>LIMIT offset num</code></summary>
+
+paginates the merged results, returning `num` documents starting at `offset`. Defaults to offset `0` and `10` results. The total may not exceed the server's `MAXSEARCHRESULTS` limit.
+</details>
+
+<details open>
+<summary><code>PARAMS nargs name value [name value ...]</code></summary>
+
+binds query parameters referenced in the command — most importantly the query vector referenced by `$param` in the `VSIM` clause. `nargs` is the number of name/value words that follow.
+</details>
+
+## Return
+
+`FT.HYBRID` returns a map reply with four fields:
+
+- `total_results` — the total number of documents matched across the text and vector pipelines.
+- `results` — an array of matches. Without `LOAD`, each entry contains `__key` and the combined score under `__score` (or under the `COMBINE` `YIELD_SCORE_AS` alias). With `LOAD`, the requested fields are returned instead. Any text/vector `YIELD_SCORE_AS` scores are added too, but only for documents that were present in that pipeline.
+- `warnings` — an array of warning strings (empty when there are none).
+- `execution_time` — the server-side execution time, in milliseconds.
+
+The combined score is computed by the active `COMBINE` method (`RRF` by default, otherwise `LINEAR`).
+
+## Examples
+
+First, create an index with a TEXT field and a VECTOR field, and add a few documents (each `vec` field holds a binary FLOAT32 vector):
+
+``` bash
+dragonfly> FT.CREATE idx ON HASH PREFIX 1 doc: SCHEMA title TEXT vec VECTOR FLAT 6 TYPE FLOAT32 DIM 2 DISTANCE_METRIC L2
+OK
+```
+
+<details open>
+<summary><b>Basic hybrid search (default RRF)</b></summary>
+
+Combine the text query `running` with a nearest-neighbor vector search and fuse the rankings with the default Reciprocal Rank Fusion. `$q` is a binary FLOAT32 little-endian vector passed via `PARAMS` (here the 2-dimensional vector `[1.0, 0.0]`).
+
+``` bash
+dragonfly> FT.HYBRID idx SEARCH "running" VSIM @vec $q KNN 3 PARAMS 2 q "\x00\x00\x80?\x00\x00\x00\x00"
+1) "total_results"
+2) (integer) 3
+3) "results"
+4) 1) 1) "__key"
+      2) "doc:1"
+      3) "__score"
+      4) "0.0327869"
+   2) 1) "__key"
+      2) "doc:2"
+      3) "__score"
+      4) "0.0322581"
+   3) 1) "__key"
+      2) "doc:3"
+      3) "__score"
+      4) "0.015873"
+5) "warnings"
+6) (empty array)
+7) "execution_time"
+8) "0.527124"
+```
+</details>
+
+<details open>
+<summary><b>Load fields and yield every score</b></summary>
+
+Return the `title` field and expose the text score (`tscore`), the vector similarity (`vscore`), and the combined RRF score (`cscore`). Score aliases are omitted for documents that did not appear in that pipeline — `doc:3` does not match the text query, so it has no `tscore`.
+
+``` bash
+dragonfly> FT.HYBRID idx SEARCH "running" YIELD_SCORE_AS tscore VSIM @vec $q KNN 3 YIELD_SCORE_AS vscore COMBINE RRF 0 YIELD_SCORE_AS cscore LOAD 1 title PARAMS 2 q "\x00\x00\x80?\x00\x00\x00\x00"
+1) "total_results"
+2) (integer) 3
+3) "results"
+4) 1) 1) "tscore"
+      2) "0.426395"
+      3) "title"
+      4) "red running shoes"
+      5) "cscore"
+      6) "0.0327869"
+      7) "vscore"
+      8) "1"
+   2) 1) "tscore"
+      2) "0.426395"
+      3) "title"
+      4) "blue running shoes"
+      5) "cscore"
+      6) "0.0322581"
+      7) "vscore"
+      8) "0.980392"
+   3) 1) "title"
+      2) "red dress"
+      3) "cscore"
+      4) "0.015873"
+      5) "vscore"
+      6) "0.333333"
+5) "warnings"
+6) (empty array)
+7) "execution_time"
+8) "2.053453"
+```
+</details>
+
+<details open>
+<summary><b>Weighted linear combination</b></summary>
+
+Use a `LINEAR` combination that weights the text score at `0.7` and the vector similarity at `0.3`. Scores are min-max normalized before weighting, so the best match scores `1` and the worst scores `0`.
+
+``` bash
+dragonfly> FT.HYBRID idx SEARCH "running" VSIM @vec $q KNN 3 COMBINE LINEAR 4 ALPHA 0.7 BETA 0.3 PARAMS 2 q "\x00\x00\x80?\x00\x00\x00\x00"
+1) "total_results"
+2) (integer) 3
+3) "results"
+4) 1) 1) "__key"
+      2) "doc:1"
+      3) "__score"
+      4) "1"
+   2) 1) "__key"
+      2) "doc:2"
+      3) "__score"
+      4) "0.97"
+   3) 1) "__key"
+      2) "doc:3"
+      3) "__score"
+      4) "0"
+5) "warnings"
+6) (empty array)
+7) "execution_time"
+8) "0.362457"
+```
+</details>
+
+## See also
+
+[`FT.SEARCH`](./ft.search.md) | [`FT.AGGREGATE`](./ft.aggregate.md) | [`FT.CREATE`](./ft.create.md)
+
+## Related topics
+
+- [RediSearch](https://redis.io/docs/latest/operate/oss_and_stack/stack-with-enterprise/search/)

--- a/docs/command-reference/search/ft.search.md
+++ b/docs/command-reference/search/ft.search.md
@@ -259,7 +259,7 @@ dragonfly> FT.SEARCH books-idx "python" WITHSCORES SCORER TFIDF
 
 ## See also
 
-[`FT.CREATE`](./ft.create.md)
+[`FT.CREATE`](./ft.create.md) | [`FT.HYBRID`](./ft.hybrid.md)
 
 ## Related topics
 

--- a/docs/command-reference/search/ft.search.md
+++ b/docs/command-reference/search/ft.search.md
@@ -8,6 +8,8 @@ description: Searches the index with a query, returning docs or just IDs
 
     FT.SEARCH index query
       [NOCONTENT]
+      [WITHSCORES]
+      [SCORER scorer_name]
       [LOAD count identifier [AS property] [ identifier [AS property] ...]]
       [RETURN count identifier [AS property] [ identifier [AS property] ...]]
       [SORTBY sortby [ ASC | DESC] [WITHCOUNT]]
@@ -38,6 +40,12 @@ is index name. You must first create the index using [`FT.CREATE`](./ft.create.m
 
 is text query to search. If it's more than a single word, put it in quotes.
 Refer to [query syntax](https://redis.io/docs/latest/develop/interact/search-and-query/query/) for more details.
+
+The query language supports the following operators:
+
+- `~term` — optional match: documents matching the term are scored higher but the term is not required.
+- `w'glob*pattern'` — glob wildcard matching on TEXT and TAG fields (e.g., `w'py*'` matches `python`).
+- `"exact phrase"` — exact phrase search; use `"term1 term2"~N` (slop) to allow up to `N` word gaps between terms.
 </details>
 
 ## Optional arguments
@@ -48,6 +56,22 @@ Refer to [query syntax](https://redis.io/docs/latest/develop/interact/search-and
 returns the document IDs and not the content.
 
 This is useful if Dragonfly is storing an index on an external document collection.
+</details>
+
+<details open>
+<summary><code>WITHSCORES</code></summary>
+
+includes the relevance score of each result in the reply. When `WITHSCORES` is set without an explicit `SCORER`, the default scorer is `BM25STD`.
+</details>
+
+<details open>
+<summary><code>SCORER scorer_name</code></summary>
+
+uses the specified scoring function to rank results. Supported scorers:
+
+- `BM25STD` — BM25 with standard per-field TF tracking (default when `WITHSCORES` is used).
+- `TFIDF` — classic TF-IDF scoring.
+- `TFIDF.DOCNORM` — TF-IDF with document-length normalization.
 </details>
 
 <details open>
@@ -123,6 +147,8 @@ Multiple `FILTER` clauses can be used to apply filters on different fields.
 ## Return
 
 `FT.SEARCH` returns an array reply, where the first element is an integer reply of the total number of results, and then array reply pairs of document IDs, and array replies of attribute/value pairs.
+
+When `WITHSCORES` is used, each result entry includes the relevance score between the document ID and the attribute/value pairs.
 
 :::note Notes
 - If `NOCONTENT` is given, an array is returned where the first element is the total number of results, and the rest of the members are document IDs.
@@ -208,6 +234,26 @@ Search for books with "python" in any TEXT attribute, filtering by price range b
 
 ``` bash
 dragonfly> FT.SEARCH books-idx "python" FILTER price 10 50
+```
+</details>
+
+<details open>
+<summary><b>Search with relevance scores</b></summary>
+
+Search for books with "python" in any TEXT attribute and include the BM25STD relevance score for each result.
+
+``` bash
+dragonfly> FT.SEARCH books-idx "python" WITHSCORES
+```
+</details>
+
+<details open>
+<summary><b>Search with a specific scorer</b></summary>
+
+Search for books with "python" in any TEXT attribute using the TFIDF scorer.
+
+``` bash
+dragonfly> FT.SEARCH books-idx "python" WITHSCORES SCORER TFIDF
 ```
 </details>
 

--- a/docs/command-reference/server-management/bgsave.md
+++ b/docs/command-reference/server-management/bgsave.md
@@ -10,17 +10,18 @@ import PageTitle from '@site/src/components/PageTitle';
 
 ## Syntax
 
-    BGSAVE SAVE [RDB|DF] [cloud_uri] [filename]
+    BGSAVE [SCHEDULE] [RDB|DF] [cloud_uri] [filename]
 
 **Time complexity:** O(1)
 
 **ACL categories:** @admin, @slow, @dangerous
 
-Equvalent to [SAVE](../server-management/save) and kept for compatibility reasons.
+Equivalent to [SAVE](../server-management/save) and kept for compatibility reasons.
 
+The optional `SCHEDULE` subcommand is accepted for client compatibility but is a no-op: concurrent saves are still rejected and saves are not queued.
 
 [tp]: https://redis.io/topics/persistence
 
 ## Return
 
-[Simple string reply](https://valkey.io/topics/protocol/#simple-strings): `Background saving started` if `BGSAVE` started correctly or `Background saving scheduled` when used with the `SCHEDULE` subcommand.
+[Simple string reply](https://valkey.io/topics/protocol/#simple-strings): `OK`. Dragonfly replies with a plain `OK` for `BGSAVE` (including when invoked with the `SCHEDULE` subcommand), not the Redis-style `Background saving started` / `Background saving scheduled` strings.

--- a/docs/command-reference/server-management/client-list.md
+++ b/docs/command-reference/server-management/client-list.md
@@ -10,7 +10,9 @@ import PageTitle from '@site/src/components/PageTitle';
 
 ## Syntax
 
-    CLIENT LIST
+```text
+CLIENT LIST [TYPE <type>] [ID <client-id> [client-id ...]]
+```
 
 **Time complexity:** O(N) where N is the number of client connections
 
@@ -18,6 +20,10 @@ import PageTitle from '@site/src/components/PageTitle';
 
 The `CLIENT LIST` command returns information and statistics about the client
 connections server in a mostly human readable format.
+
+The optional `TYPE` filter limits the output to clients of the specified type.
+The optional `ID` filter limits the output to clients with the specified client ID(s).
+`TYPE` and `ID` are mutually exclusive — only one of the two filters may be supplied per call.
 
 
 ## Return

--- a/docs/managing-dragonfly/cluster-mode.md
+++ b/docs/managing-dragonfly/cluster-mode.md
@@ -197,7 +197,7 @@ such as adding/removing nodes, changing hostnames, etc.
   reference for how to set up and configure a cluster. This script starts a cluster locally, but
   much of its logic can be reused for nodes present on remote machines as well.
 - If you're getting errors trying to issue the `DFLYCLUSTER CONFIG`, check Dragonfly's logs (you
-  can pass `--logtostdout` temporarily) to see why the config was rejected.
+  can pass `--logtostderr` temporarily) to see why the config was rejected.
 - Dragonfly supports the migration of data slots between nodes as well. Detailed explaination can
   be found in one of our blog posts [here](https://www.dragonflydb.io/blog/redis-and-dragonfly-cluster-design-comparison).
   We will update the documentation to reflect these steps soon.

--- a/docs/managing-dragonfly/flags.md
+++ b/docs/managing-dragonfly/flags.md
@@ -135,6 +135,11 @@ flags which include specified substring in either in the name, description or pa
 
   `default: false`
 
+### `--container_iteration_yield_interval_usec`
+  Yield the fiber every N microseconds during container iteration. 0 disables yielding.
+
+  `default: 0`
+
 ### `--tcp_keepalive`
   The period in seconds of inactivity after which keep-alives are triggerred,
   the duration until an inactive connection is terminated is twice the specified time.
@@ -286,15 +291,15 @@ flags which include specified substring in either in the name, description or pa
 
   `default: 0.1`
 
-### `--tiered_storage_write_depth`
-  Maximum number of concurrent stash requests issued by background offload. 
-
-  `default: 200`
-
 ### `--tiered_min_value_size`
   Minimum size of values eligible for offloading. Must be at least 64
 
   `default: 64`
+
+### `--tiered_max_pending_stash_bytes`
+  Maximum bytes in-flight to disk before rejecting new stashes or applying client backpressure. Allows batching writes to saturate disk I/O even with few clients.
+
+  `default: 256.0KiB`
 
 ### `--keys_output_limit`
   Maximum number of keys output by keys command.
@@ -315,6 +320,16 @@ flags which include specified substring in either in the name, description or pa
   Maximum listpack size, default is 8kb.
   
   `default: -2`
+
+### `--listpack_max_bytes`
+  Maximum total bytes of a hash in listpack encoding before converting to a hash table.
+
+  `default: 1024`
+
+### `--listpack_max_field_len`
+  Maximum length of a hash field or value to be stored in listpack encoding.
+
+  `default: 64`
 
 ### `--admin_nopass`
   If set, would enable open admin access to console on the assigned port, without authorization needed.
@@ -437,6 +452,11 @@ flags which include specified substring in either in the name, description or pa
 
   `default: true`
 
+### `--s3_use_helio_client`
+  If true, use helio's native S3 client; if false, use aws-sdk-cpp.
+
+  `default: true`
+
 ### `--slowlog_log_slower_than`
   Add commands slower than this threshold to slow log. The value is expressed in microseconds 
   and if it's negative disables the slowlog.
@@ -460,6 +480,11 @@ flags which include specified substring in either in the name, description or pa
   
   `default: 65536`
 
+### `--serialization_tagged_chunks`
+  Allow serializer output to be split into tagged chunks and reassembled by receiver.
+
+  `default: false`
+
 ### `--aclfile`
   Path and name to aclfile.
 
@@ -475,6 +500,16 @@ flags which include specified substring in either in the name, description or pa
   Ip that cluster commands announce to the client.
 
   `default: ""`
+
+### `--cluster_coordinator_connect_timeout_ms`
+  Timeout in milliseconds for coordinator to connect to remote shards.
+
+  `default: 3000`
+
+### `--cluster_coordinator_response_timeout_ms`
+  Timeout in milliseconds for coordinator to read responses from remote shards.
+
+  `default: 3000`
 
 ### `--shard_repl_backlog_len`
   The length of the circular replication log per shard.
@@ -506,20 +541,25 @@ flags which include specified substring in either in the name, description or pa
 
   `default: ""`
 
+### `--logbuflevel`
+  Buffer log messages logged at this level or below. (-1 means don't buffer; 0 means buffer INFO only).
+
+  `default: 0`
+
+### `--logbufsecs`
+  Buffer log messages for at most this many seconds.
+
+  `default: 30`
+
 ### `--logtostderr`
   Log messages go to stderr instead of logfiles.
-
-  `default: false`
-
-### `--logtostdout`
-  Log messages go to stdout instead of logfiles.
 
   `default: false`
 
 ### `--max_log_size`
   Approx. maximum log file size (in MB). A value of 0 will be silently overridden to 1. 
 
-  `default: 1800`
+  `default: 200`
 
 ### `--minloglevel`
   Messages logged at a lower level than this don't actually get logged anywhere. 
@@ -611,6 +651,16 @@ flags which include specified substring in either in the name, description or pa
 
   `default: true`
 
+### `--enable_memcache_io_loop_v2`
+  Enable the event-driven IoLoopV2 for non-TLS Memcache connections.
+
+  `default: true`
+
+### `--enable_resp_io_loop_v2`
+  Enable the event-driven IoLoopV2 for non-TLS RESP connections.
+
+  `default: false`
+
 ### `--enable_tcp_defer_accept`
   Enable TCP_DEFER_ACCEPT option on server sockets.
 
@@ -630,11 +680,6 @@ flags which include specified substring in either in the name, description or pa
   If true, uses flat json implementation.
 
   `default: false`
-
-### `--experimental_io_loop_v2`
-  Use the new io loop implementation.
-
-  `default: true`
 
 ### `--experimental_replicaof_v2`
   Use ReplicaOfV2 algorithm for initiating replication.
@@ -673,6 +718,11 @@ flags which include specified substring in either in the name, description or pa
 
 ### `--info_replication_valkey_compatible`
   When true, output valkey compatible values for info-replication.
+
+  `default: true`
+
+### `--journal_omit_redundant_writes`
+  If true, omit journal writes for keys during full sync that are yet to be reached by the serialization loop. Reduces full sync overhead.
 
   `default: true`
 
@@ -869,7 +919,7 @@ flags which include specified substring in either in the name, description or pa
 ### `--rdb_sbf_chunked`
   Enable new save format for saving SBFs in chunks.
 
-  `default: false`
+  `default: true`
 
 ### `--registered_buffer_size`
   Size of registered buffer for IoUring fixed read/writes.
@@ -1080,6 +1130,11 @@ flags which include specified substring in either in the name, description or pa
   Use range tree for numeric index. If false, use a simple implementation with btree_set. Range tree is more memory efficient and faster for range queries, but slower for single value queries.
 
   `default: true`
+
+### `--use_oah_set`
+  If true, store SET values in OAHSet instead of StringSet.
+
+  `default: false`
 
 ### `--user`
   If not empty - drop privileges to this user (and their primary group) after binding ports. Accepts username or numeric uid. If `--dir` is set, chowns the data directory to this user.

--- a/docs/managing-dragonfly/monitoring.md
+++ b/docs/managing-dragonfly/monitoring.md
@@ -18,3 +18,7 @@ If you're using kubernetes, Metrics are also available on admin port `9999`. You
 * Closing connection
 curl: (1) Received HTTP/0.9 when not allowed
 ```
+
+## Replication Metrics
+
+The `/metrics` endpoint also exposes replication information. These metrics include details about the replication role of the instance, connected replicas, and replication lag, allowing you to monitor the health and status of your Dragonfly replication setup via Prometheus.

--- a/docs/managing-dragonfly/scripting.md
+++ b/docs/managing-dragonfly/scripting.md
@@ -48,3 +48,11 @@ script tried accessing undeclared key
  
 To allow accessing any keys, including undeclared, the flag `allow-undeclared-keys` should be used. 
 This option is disabled by default because unpredictability, atomicity and multithreading don't mix well. If enabled, Dragonfly has to stop all other operations when the script is running.
+
+## Sandbox restrictions
+
+Dragonfly's Lua environment runs in a restricted sandbox. The following restrictions apply:
+
+- The `load()` function is restricted to text mode only (binary chunks are not accepted).
+- The built-in `rawset`, `setmetatable`, and `getmetatable` functions are replaced with protected versions that refuse to modify or read the metatable of the global environment (`_G`). (These functions can still be reassigned or shadowed inside a script; the protection guards the global environment, it does not prevent a script from overriding the names.)
+- The `dragonfly.randstr()` helper validates its input size argument and rejects values that exceed allowed limits.

--- a/docs/managing-dragonfly/tiering.md
+++ b/docs/managing-dragonfly/tiering.md
@@ -36,7 +36,7 @@ Here are the main server flags related to SSD data tiering:
   See upload/offload thresholds and examples below for more details.
 - `tiered_offload_threshold`: The ratio of free memory, below which values will be actively offloaded to disk by a background process.
 - `tiered_upload_threshold`: The ratio of free memory, below which values are no longer returned to memory when read.
-- `tiered_storage_write_depth`: The maximum number of concurrent disk writes to avoid overloading the disk.
+- `tiered_max_pending_stash_bytes`: The maximum number of bytes in-flight to disk before new stashes are rejected or client backpressure is applied. This allows batching writes to saturate disk I/O even with few clients. (Replaces the retired `tiered_storage_write_depth` flag.)
 - `tiered_max_file_size`: The maximum file size in bytes (must be multiples of 256MB), usually determined automatically.
 - `tiered_min_value_size`: This option can be used to raise the 64-byte value limit to offload only larger values.
 - `registered_buffer_size`: The size of registered buffers to use for zero-copy reads and writes with `io_uring`.
@@ -139,4 +139,4 @@ with locally attached SSDs is recommended. See below for specific cloud provider
 - Dragonfly v1.35 (release notes for [v1.35.0](https://github.com/dragonflydb/dragonfly/releases/tag/v1.35.0)
   and [v1.35.1](https://github.com/dragonflydb/dragonfly/releases/tag/v1.35.1)) is the first official release of SSD data tiering.
 - If you encounter any problems while using this feature, please report them by [filing a GitHub issue](https://github.com/dragonflydb/dragonfly/issues/).
-- Data tiering is currently supported for string values and experimentally for list nodes. It is not supported for BitMap and HyperLogLog operations.
+- Data tiering is currently supported for string values and, experimentally, for list nodes and mutable hash commands. It is not supported for BitMap and HyperLogLog operations.

--- a/tools/docsync/docs_sync.py
+++ b/tools/docsync/docs_sync.py
@@ -46,6 +46,7 @@ import argparse
 import json
 import os
 import re
+import shlex
 import subprocess
 import sys
 import time
@@ -646,13 +647,30 @@ def kill_docker(session: DockerSession) -> None:
                    capture_output=True)
 
 
+def tokenize_invocation(cmd: str) -> list[str]:
+    """Split a `dragonfly>` command line into redis-cli argv.
+
+    Uses shell-style tokenization (shlex) so quoted values are unquoted the
+    way a shell / the redis-cli REPL would handle them — e.g.
+    `HSETEX k 30 user "alice"` yields the value `alice`, not the literal
+    `"alice"` (which the server would store with the quotes, rendering as
+    `"\\"alice\\""` under --no-raw). Falls back to a plain whitespace split
+    if the line is not valid shell syntax (e.g. an unbalanced quote), so a
+    malformed example degrades to the old behaviour instead of raising.
+    """
+    try:
+        return shlex.split(cmd)
+    except ValueError:
+        return cmd.split()
+
+
 def verify_invocations(session: DockerSession,
                        invocations: list[str]) -> list[dict]:
     """Run each invocation and capture the actual output. Returns a list of
     {invocation, stdout, stderr, returncode}."""
     out: list[dict] = []
     for inv in invocations:
-        argv = inv.split()
+        argv = tokenize_invocation(inv)
         stdout, stderr, rc = session.exec(argv)
         out.append({
             "invocation": inv,
@@ -780,7 +798,7 @@ def verify_and_substitute_examples(
                 i += 1
                 continue
             cmd = line[len("dragonfly> "):].strip()
-            argv = cmd.split()
+            argv = tokenize_invocation(cmd)
             stdout, stderr, rc = session.exec(argv)
             invocation_count += 1
             rebuilt.append(line)


### PR DESCRIPTION
## Summary

Syncs the command-reference and managing-dragonfly docs from Dragonfly **v1.38.0** to **v1.39.0** using the in-repo docsync tooling (`flags_sync` + `docs_sync`), then takes the story one step further: every machine-generated change was replayed against a live v1.39.0 Docker container and the C++ source, and corrected wherever the tool was wrong. A brand-new page documents the Dragonfly-specific `FT.HYBRID` command, and the sync harness itself was patched so quoted example values are no longer mangled — the root cause of the example corruption repaired here.

Every changed file is traceable to a bullet below.

**Reviewer focus — start here:**
1. The **new `FT.HYBRID` page** (`docs/command-reference/search/ft.hybrid.md`, 245 lines) — a Dragonfly-specific command, so there is no upstream reference to diff against. Please scrutinize the syntax, the `COMBINE RRF`/`LINEAR` semantics, the `KNN`/`RANGE` mutual exclusion, and the `RANGE` cannot-combine-with-`FILTER` constraint.
2. The **corrections** below, where the synced output was factually wrong and was overridden by hand.

## New documentation

- **`search/ft.hybrid.md`** (new, 245 lines) — full reference for Dragonfly's hybrid full-text (`SEARCH`) + vector (`VSIM` / `KNN` / `RANGE`) search: `COMBINE RRF` (default) and `COMBINE LINEAR` rank fusion, `YIELD_SCORE_AS` (settable independently for the text, vector, and combined scores), `LOAD`, `LIMIT`, `PARAMS`, the four-field map reply, and three worked examples (default RRF, per-pipeline score yielding, weighted linear) whose output was captured from a live v1.39.0 container.
- **`compatibility.md`** — adds an `FT.HYBRID` row to the Search family, marked `Fully supported`.
- **Cross-references to `FT.HYBRID`** added from `ft.search.md`, `ft.aggregate.md`.

## Verified & corrected sync output

- **`search/ft.aggregate.md`** — documents `ADDSCORES` (adds `__score`, defaults to the BM25STD scorer) and `SCORER` (`BM25STD` / `TFIDF` / `TFIDF.DOCNORM`); **corrects** `WITHSCORES` to note it is accepted for `FT.SEARCH` compatibility but **silently ignored** by `FT.AGGREGATE` (use `ADDSCORES` to expose `__score`).
- **`search/ft.search.md`** — documents `WITHSCORES` (default scorer `BM25STD`) and `SCORER scorer_name` (`BM25STD` / `TFIDF` / `TFIDF.DOCNORM`), the score's position in the reply, and the query operators `~term` (optional), `w'glob*'` (glob on TEXT/TAG), and `"phrase"~N` (slop); plus two scored-search examples.
- **`search/ft.create.md`** — clarifies that JSON field identifiers may be a JSONPath expression (`$.title`) or a bare field name (`title`), with a new bare-name example.
- **`server-management/bgsave.md`** — corrects the syntax to `BGSAVE [SCHEDULE] [RDB|DF] ...`, documents `SCHEDULE` as a no-op (concurrent saves still rejected, not queued); **corrects** the Return to a plain `OK` (not the Redis-style `Background saving started` / `Background saving scheduled` strings); fixes an "Equvalent" typo.
- **`server-management/client-list.md`** — documents the `CLIENT LIST [TYPE <type>] [ID <client-id> ...]` filters and notes that `TYPE` and `ID` are **mutually exclusive** (one filter per call).
- **`scripting.md`** — documents the Lua sandbox restrictions and **corrects** the `rawset` / `setmetatable` / `getmetatable` description: the protected versions guard the global environment (`_G`); they do **not** prevent a script from reassigning/shadowing those names. Also notes `load()` is text-mode-only and `dragonfly.randstr()` validates its size argument.
- **`tiering.md`** — notes data tiering now covers list nodes **and mutable hash commands, experimentally**, and replaces the retired `tiered_storage_write_depth` flag with `tiered_max_pending_stash_bytes`.
- **`cluster-mode.md`** — updates the debug tip from `--logtostdout` to `--logtostderr` (the former was removed in v1.39.0).
- **`monitoring.md`** — adds a Replication Metrics section noting the `/metrics` endpoint also exposes replication role, connected replicas, and lag.

## Fixed examples

- **`hashes/hsetex.md`** — rewrites the example blocks the sync harness had corrupted into self-contained, verified v1.39.0 sequences: unquoted argument values, correct TTLs (`FIELDTTL` now `30` / `60`), and the new-fields-added return semantics for `NX` and `KEEPTTL`.
- **`generic/restore.md`** — replaces the corrupted `RESTORE` example with a real `SET` → `DUMP` → `DEL` → `RESTORE` → `GET` round-trip in a plain fence, plus a note that the payload is tied to the server's RDB version; keeps the verified "listpack/intset payloads are deeply validated on restore" prose.

## Flag reference updates

`flags.md` re-synced via `flags_sync` to v1.39.0:
- **Added:** `--container_iteration_yield_interval_usec`, `--tiered_max_pending_stash_bytes`, `--listpack_max_bytes`, `--listpack_max_field_len`, `--s3_use_helio_client`, `--serialization_tagged_chunks`, `--cluster_coordinator_connect_timeout_ms`, `--cluster_coordinator_response_timeout_ms`, `--logbuflevel`, `--logbufsecs`, `--enable_memcache_io_loop_v2`, `--enable_resp_io_loop_v2`, `--journal_omit_redundant_writes`, `--use_oah_set`.
- **Removed (retired):** `--tiered_storage_write_depth`, `--logtostdout`, `--experimental_io_loop_v2`.
- **Corrected defaults:** `--max_log_size` `1800` → `200`, `--rdb_sbf_chunked` `false` → `true`.

## Tooling

- **`tools/docsync/docs_sync.py`** — fixes the example tokenizer with a new `tokenize_invocation()` helper that uses `shlex.split` so quoted values are unquoted the way redis-cli would (e.g. `"alice"` → `alice` instead of being stored with literal quotes), with a fallback to a plain whitespace split on invalid shell syntax (unbalanced quotes). Wired into both `verify_invocations()` and `verify_and_substitute_examples()`. This is the root-cause fix for the kind of example corruption repaired in `hsetex.md` and `restore.md`.

## Verification

- `yarn build` passes.
- Command examples (`FT.HYBRID`, `HSETEX`, `RESTORE`, scoring) were run against a live **Dragonfly v1.39.0 Docker container** and the captured output is what appears in the docs.
- Behavioral corrections (`WITHSCORES` silently ignored by `FT.AGGREGATE`, `BGSAVE` returns plain `OK`, the Lua sandbox guards `_G`, `CLIENT LIST TYPE`/`ID` mutually exclusive, hash tiering experimental, the `FT.HYBRID` reply shape) were checked against the v1.39.0 C++ source.

## Notes for reviewers

- The `bgsave.md` Return correction (`Background saving started` → plain `OK`) is a **pre-existing fix** — it is not produced by the v1.38 → v1.39 sync.
- The `FT.HYBRID` `Fully supported` entry in `compatibility.md` is a **curated judgement**, not a tool-generated value.